### PR TITLE
Add option to set Datalake Version requested

### DIFF
--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -80,6 +80,7 @@ plat__cdp_iam_user_group_roles:               "{{ env.cdp.user_group.roles | def
 plat__cdp_iam_user_group_resource_roles:      "{{ env.cdp.user_group.resource_roles | default(plat__cdp_iam_user_group_resource_roles_default) }}"
 
 plat__datalake_name:                          "{{ common__datalake_name }}"
+plat__datalake_version:                       "{{ env.datalake.version | default(omit) }}"
 plat__datalake_user_sync:                     "{{ env.datalake.user_sync | default(True) }}"
 
 plat__cdp_xaccount_external_id:               "{{ env.cdp.cross_account.external_id | default(False) }}"

--- a/roles/platform/tasks/setup_aws_datalake.yml
+++ b/roles/platform/tasks/setup_aws_datalake.yml
@@ -20,6 +20,7 @@
     env: "{{ plat__env_name }}"
     instance_profile: "{{ plat__aws_idbroker_instance_profile_arn }}"
     storage: "{{ plat__aws_storage_location }}"
+    runtime: "{{ plat__datalake_version | default(omit) }}"
     tags: "{{ plat__tags }}"
     state: present
 

--- a/roles/platform/tasks/setup_azure_datalake.yml
+++ b/roles/platform/tasks/setup_azure_datalake.yml
@@ -20,5 +20,6 @@
     env: "{{ plat__env_name }}"
     managed_identity: "{{ __azure_idbroker_identity_uri }}"
     storage: "{{ plat__azure_stor_data_uri }}"
+    runtime: "{{ plat__datalake_version | default(omit) }}"
     tags: "{{ plat__tags }}"
     state: present

--- a/roles/platform/tasks/setup_gcp_datalake.yml
+++ b/roles/platform/tasks/setup_gcp_datalake.yml
@@ -20,5 +20,6 @@
     env: "{{ plat__env_name }}"
     managed_identity: "{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
     storage: "gs://{{ plat__gcp_storage_location_data }}"
+    runtime: "{{ plat__datalake_version | default(omit) }}"
     tags: "{{ plat__tags }}"
     state: present


### PR DESCRIPTION
Introduce env.datalake.version as a key to pin the version of CDP Datalake requested during deployment.

Subsequent code fetches the actually deployed version of the Datalake to ensure compatibility

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>