### PR TITLE
New Roles to facilitate creation of FreeIPA sudoers group and rule 

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -39,6 +39,7 @@ dependencies:
   'git+https://github.com/cloudera-labs/cloudera.cloud.git': 'main'
   'ansible.netcommon': '>=2.0.2'
   'community.aws': '>=1.2.0'
+  'community.general': '>=3.1.0'
   'amazon.aws': '>=1.3.0'
   'azure.azcollection': '>=1.4.0'
   'google.cloud': '>=1.0.2'

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -122,6 +122,7 @@ common__env_name_suffix:                  "{{ env.suffix | default(common__env_s
 common__datalake_name:                    "{{ env.datalake.name | default([common__namespace_cdp, common__datalake_name_suffix] | join('-')) }}"
 common__datalake_name_suffix:             "{{ env.datalake.suffix | default(common__datalake_suffix) }}"
 
+common__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
 # Deploy
 common__include_ml:                        "{{ ml is defined | bool }}"
 common__include_dw:                        "{{ dw is defined | bool }}"

--- a/roles/freeipa_host_group/defaults/main.yml
+++ b/roles/freeipa_host_group/defaults/main.yml
@@ -1,0 +1,27 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# global file for freeipa_host_group
+
+# Role prefix is 'freeipa_host_group__'
+
+# Variables used as inputs in main.yml
+freeipa_host_group__env_name:  "{{ common__env_name }}"
+freeipa_host_group__infra_type:  "{{ common__infra_type }}"
+freeipa_host_group__region:    "{{ common__region }}"
+
+# Outputs
+freeipa_host_group__host_group_name: "freeipa_server_hosts"

--- a/roles/freeipa_host_group/meta/main.yml
+++ b/roles/freeipa_host_group/meta/main.yml
@@ -15,7 +15,7 @@
 galaxy_info:
   author: Jim Enright (jenright@cloudera.com)
   description: >
-    Creation of FreeIPA host group and retrieving the login user name for these hosts.
+    Creation of FreeIPA host group.
   company: Cloudera
   license: Apache-2.0
 

--- a/roles/freeipa_host_group/meta/main.yml
+++ b/roles/freeipa_host_group/meta/main.yml
@@ -1,0 +1,41 @@
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: Jim Enright (jenright@cloudera.com)
+  description: >
+    Creation of FreeIPA host group and retrieving the login user name for these hosts.
+  company: Cloudera
+  license: Apache-2.0
+
+  min_ansible_version: 2.10
+
+  platforms:
+  - name: Debian
+    versions: all
+  - name: Fedora
+    versions: all
+  - name: GenericLinux
+    versions: all
+  - name: MacOSX
+    versions: all
+  - name: Ubuntu
+    versions: all
+
+  galaxy_tags:
+  - cloudera
+  - cdp
+  - freeipa
+
+dependencies: ['cloudera.exe.common']

--- a/roles/freeipa_host_group/tasks/main.yml
+++ b/roles/freeipa_host_group/tasks/main.yml
@@ -63,22 +63,11 @@
   ansible.builtin.set_fact:
     __freeipa_server_login_user: "{{ __env_info.environments[0].authentication.loginUserName }}"
 
-# Find the workload username (required for any calls to the freeipa.ansible_freeipa module)
-- name: Query CDP Caller
-  cloudera.cloud.iam_user_info:
-    current_user: yes
-  register: __cdp_iam_current_user_info
-
-- name: Set facts for CDP Caller Workload Username
-  ansible.builtin.set_fact:
-    __cdp_workload_username: "{{ __cdp_iam_current_user_info.users[0].workloadUsername }}"
-
 # Add the FreeIPA server and username to the inventory
 - name: Add FreeIPA servers to inventory
   ansible.builtin.add_host:
     name: "{{ item }}" 
     groups: "{{ freeipa_host_group__host_group_name }}" 
     ansible_user: "{{ __freeipa_server_login_user }}"
-    cdp_workload_user: "{{ __cdp_workload_username }}"
   loop: "{{ __freeipa_server_public_ip }}"
 

--- a/roles/freeipa_host_group/tasks/main.yml
+++ b/roles/freeipa_host_group/tasks/main.yml
@@ -52,22 +52,10 @@
 #   when: freeipa_host_group__infra_type == "gcp"
 #   block:
 
-# Get the CDP environment details to find the loginUserName (required to SSH into FreeIPA server)
-- name: Query CDP Environment
-  cloudera.cloud.env_info:
-    name: "{{ freeipa_host_group__env_name }}"
-    descendants: true
-  register: __env_info
-
-- name: Set facts for the login user to the FreeIPA server
-  ansible.builtin.set_fact:
-    __freeipa_server_login_user: "{{ __env_info.environments[0].authentication.loginUserName }}"
-
 # Add the FreeIPA server and username to the inventory
 - name: Add FreeIPA servers to inventory
   ansible.builtin.add_host:
     name: "{{ item }}" 
     groups: "{{ freeipa_host_group__host_group_name }}" 
-    ansible_user: "{{ __freeipa_server_login_user }}"
   loop: "{{ __freeipa_server_public_ip }}"
 

--- a/roles/freeipa_host_group/tasks/main.yml
+++ b/roles/freeipa_host_group/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Get the FreeIPA server details in order to find its public IP address
+- name: Query the FreeIPA status
+  cloudera.cloud.freeipa_info:
+    name: "{{ freeipa_host_group__env_name }}"
+  register: __freeipa_info
+
+# Extract the instance ID for the FreeIPA server
+- name: Set facts for FreeIPA server instance ID
+  ansible.builtin.set_fact:
+    __freeipa_server_instance_id: "{{ __freeipa_info.environments.instances.keys() | first }}"
+
+# Get instance details for specific infra_type - AWS
+- name: Gather FreeIPA instance details on AWS
+  when: freeipa_host_group__infra_type == "aws"
+  block:
+    - name: Gather EC2 instance information using ID
+      community.aws.ec2_instance_info:
+        region: "{{ freeipa_host_group__region }}"
+        instance_ids:
+          - "{{ __freeipa_server_instance_id }}"
+      register: __ec2_node_info
+
+    - name: Set facts for the FreeIPA server IP
+      ansible.builtin.set_fact:
+        __freeipa_server_public_ip: "{{ __ec2_node_info.instances | map(attribute='public_ip_address') }}"
+
+# TODO: A block per cloud provider - azure
+# Get instance details for specific infra_type - Azure
+# - name: Gather FreeIPA instance details on Azure
+#   when: freeipa_host_group__infra_type == "azure"
+#   block:
+
+# TODO: A block per cloud provider - GCP
+# Get instance details for specific infra_type - GCP
+# - name: Gather FreeIPA instance details on GCP
+#   when: freeipa_host_group__infra_type == "gcp"
+#   block:
+
+# Get the CDP environment details to find the loginUserName (required to SSH into FreeIPA server)
+- name: Query CDP Environment
+  cloudera.cloud.env_info:
+    name: "{{ freeipa_host_group__env_name }}"
+    descendants: true
+  register: __env_info
+
+- name: Set facts for the login user to the FreeIPA server
+  ansible.builtin.set_fact:
+    __freeipa_server_login_user: "{{ __env_info.environments[0].authentication.loginUserName }}"
+
+# Find the workload username (required for any calls to the freeipa.ansible_freeipa module)
+- name: Query CDP Caller
+  cloudera.cloud.iam_user_info:
+    current_user: yes
+  register: __cdp_iam_current_user_info
+
+- name: Set facts for CDP Caller Workload Username
+  ansible.builtin.set_fact:
+    __cdp_workload_username: "{{ __cdp_iam_current_user_info.users[0].workloadUsername }}"
+
+# Add the FreeIPA server and username to the inventory
+- name: Add FreeIPA servers to inventory
+  ansible.builtin.add_host:
+    name: "{{ item }}" 
+    groups: "{{ freeipa_host_group__host_group_name }}" 
+    ansible_user: "{{ __freeipa_server_login_user }}"
+    cdp_workload_user: "{{ __cdp_workload_username }}"
+  loop: "{{ __freeipa_server_public_ip }}"
+

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -63,7 +63,7 @@ plat__xacccount_credential_name:              "{{ common__xaccount_credential_na
 plat__workload_analytics:                     "{{ env.workload_analytics | default(True) }}"
 plat__tunnel:                                 "{{ env.tunnel | default(True) }}"
 
-plat__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
+plat__env_admin_password:                     "{{ common__env_admin_password }}"
 
 plat__vpc_public_subnet_cidrs:                "{{ common__vpc_public_subnet_cidrs }}"
 plat__vpc_private_subnet_cidrs:               "{{ common__vpc_private_subnet_cidrs }}"

--- a/roles/sudoers/defaults/main.yml
+++ b/roles/sudoers/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# global file for sudoers
+
+# Role prefix is 'sudoers__'
+
+# Variables used as inputs in main.yml
+sudoers__env_admin_username:                     "{{ cdp_workload_user }}"
+sudoers__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
+
+sudoers__sudo_group_name:                        sudoers
+sudoers__sudo_group_users:                       []
+# Flag to determine if we want to remove (=True) or retain (=False) existing users in sudoers group
+sudoers__purge_users_in_group:                   False                         
+
+sudoers__sudorule_name:                          admin_all_rule

--- a/roles/sudoers/defaults/main.yml
+++ b/roles/sudoers/defaults/main.yml
@@ -19,8 +19,7 @@
 # Role prefix is 'sudoers__'
 
 # Variables used as inputs in main.yml
-sudoers__env_admin_username:                     "{{ cdp_workload_user }}"
-sudoers__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
+sudoers__env_admin_password:                     "{{ common__env_admin_password }}"
 
 sudoers__sudo_group_name:                        sudoers
 sudoers__sudo_group_users:                       []

--- a/roles/sudoers/meta/main.yml
+++ b/roles/sudoers/meta/main.yml
@@ -15,7 +15,8 @@
 galaxy_info:
   author: Jim Enright (jenright@cloudera.com)
   description: >
-    Adding specified users to FreeIPA sudoers group and creation of a sudo rule to allow passwordless sudo for the group. Existing users in the sudoers can be purged or retained depending on the value of the sudoers__purge_users_in_group flag.
+    Add specified users to FreeIPA sudoers group and create a passwordless sudo rule for the group. 
+    Existing group members can be purged or retained depending on the value of the sudoers__purge_users_in_group flag.
   company: Cloudera
   license: Apache-2.0
 

--- a/roles/sudoers/meta/main.yml
+++ b/roles/sudoers/meta/main.yml
@@ -1,0 +1,41 @@
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+galaxy_info:
+  author: Jim Enright (jenright@cloudera.com)
+  description: >
+    Adding specified users to FreeIPA sudoers group and creation of a sudo rule to allow passwordless sudo for the group. Existing users in the sudoers can be purged or retained depending on the value of the sudoers__purge_users_in_group flag.
+  company: Cloudera
+  license: Apache-2.0
+
+  min_ansible_version: 2.10
+
+  platforms:
+  - name: Debian
+    versions: all
+  - name: Fedora
+    versions: all
+  - name: GenericLinux
+    versions: all
+  - name: MacOSX
+    versions: all
+  - name: Ubuntu
+    versions: all
+
+  galaxy_tags:
+  - cloudera
+  - cdp
+  - freeipa
+
+dependencies: ['cloudera.exe.common']

--- a/roles/sudoers/tasks/initialize.yml
+++ b/roles/sudoers/tasks/initialize.yml
@@ -15,22 +15,18 @@
 # limitations under the License.
 
 # Find the current CDP username. 
-- name: Find and set env_admin_username
-  include_tasks: initialize.yml
+# This is used in the tasks to create the FreeIPA group and sudo rule.
+# Note - the user is required to have PowerUser role in the CDP environment.
+- name: Query CDP Caller to save user info
+  cloudera.cloud.iam_user_info:
+    current_user: yes
+  register: __cdp_iam_current_user_info
 
-# Remove the FreeIPA sudo rule
-- name: Remove sudo rule for passwordless sudo
-  community.general.ipa_sudorule:
-    ipa_user: "{{ sudoers__env_admin_username }}"
-    ipa_pass: "{{ sudoers__env_admin_password }}"
-    name: "{{ sudoers__sudorule_name }}"
-    state: absent
+- name: Set fact for CDP Environment Admin User
+  ansible.builtin.set_fact:
+    sudoers__env_admin_username: "{{ __cdp_iam_current_user_info.users[0].workloadUsername }}"
 
-# Remove the FreeIPA group for sudo
-- name: Remove sudoers group
-  community.general.ipa_group:
-    ipa_user: "{{ sudoers__env_admin_username }}"
-    ipa_pass: "{{ sudoers__env_admin_password }}"
-    name: "{{ sudoers__sudo_group_name }}"
-    state: absent
-  register: sudoers_group
+- name: Print Environment Admin Username
+  ansible.builtin.debug:
+    msg: "CDP Environment Admin Username is {{ sudoers__env_admin_username }}"
+    verbosity: 1

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# If don't want to purge existing users from the FreeIPA group,
+# we'll query the group to get current users 
+- name: Query sudoers group for list of users
+  when: not sudoers__purge_users_in_group
+  block:
+    # Note - below creates the group if it doesn't already exist
+    - name: Create or query the sudoers group
+      community.general.ipa_group:
+        ipa_user: "{{ sudoers__env_admin_username }}"
+        ipa_pass: "{{ sudoers__env_admin_password }}"
+        name: "{{ sudoers__sudo_group_name }}"
+        state: present
+      register: sudoers_group
+
+    - name: Set facts for current user members of the group
+      ansible.builtin.set_fact:
+        __sudo_existing_group_users: "{{ sudoers_group.group.member_user | default([]) }}"
+
+# Final list of users to add to sudoers group -
+# either combined with existing group members or overrides
+- name: Create list of users to add to sudoers group
+  ansible.builtin.set_fact:
+    __sudo_group_users: "{{ sudoers__sudo_group_users | union(__sudo_existing_group_users) if not sudoers__purge_users_in_group else sudoers__sudo_group_users }}"
+
+# Create a FreeIPA group for sudo and add users
+- name: Add users to the sudoers group
+  community.general.ipa_group:
+    ipa_user: "{{ sudoers__env_admin_username }}"
+    ipa_pass: "{{ sudoers__env_admin_password }}"
+    name: "{{ sudoers__sudo_group_name }}"
+    user: "{{ __sudo_group_users }}"
+    state: present
+
+# Create FreeIPA sudo rule
+- name: Add sudo rule for passwordless sudo
+  community.general.ipa_sudorule:
+    ipa_user: "{{ sudoers__env_admin_username }}"
+    ipa_pass: "{{ sudoers__env_admin_password }}"
+    name: "{{ sudoers__sudorule_name }}"
+    cmdcategory: all
+    hostcategory: all
+    sudoopt: "!authenticate"
+    usergroup:
+      - "{{ sudoers__sudo_group_name }}"
+    state: present

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -15,21 +15,8 @@
 # limitations under the License.
 
 # Find the current CDP username. 
-# This is used in the tasks to create the FreeIPA group and sudo rule.
-# Note - the user is required to have PowerUser role in the CDP environment.
-- name: Query CDP Caller to save user info
-  cloudera.cloud.iam_user_info:
-    current_user: yes
-  register: __cdp_iam_current_user_info
-
-- name: Set fact for CDP Environment Admin User
-  ansible.builtin.set_fact:
-    sudoers__env_admin_username: "{{ __cdp_iam_current_user_info.users[0].workloadUsername }}"
-
-- name: Print Environment Admin Username
-  ansible.builtin.debug:
-    msg: "CDP Environment Admin Username is {{ sudoers__env_admin_username }}"
-    verbosity: 1
+- name: Find and set env_admin_username
+  include_tasks: initialize.yml
 
 # If don't want to purge existing users from the FreeIPA group,
 # we'll query the group to get current users 

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -14,6 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Find the current CDP username. 
+# This is used in the tasks to create the FreeIPA group and sudo rule.
+# Note - the user is required to have PowerUser role in the CDP environment.
+- name: Query CDP Caller to save user info
+  cloudera.cloud.iam_user_info:
+    current_user: yes
+  register: __cdp_iam_current_user_info
+
+- name: Set fact for CDP Environment Admin User
+  ansible.builtin.set_fact:
+    sudoers__env_admin_username: "{{ __cdp_iam_current_user_info.users[0].workloadUsername }}"
+
+- name: Print Environment Admin Username
+  ansible.builtin.debug:
+    msg: "CDP Environment Admin Username is {{ sudoers__env_admin_username }}"
+    verbosity: 1
 
 # If don't want to purge existing users from the FreeIPA group,
 # we'll query the group to get current users 

--- a/roles/sudoers/tasks/teardown.yml
+++ b/roles/sudoers/tasks/teardown.yml
@@ -1,0 +1,32 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Remove the FreeIPA sudo rule
+- name: Remove sudo rule for passwordless sudo
+  community.general.ipa_sudorule:
+    ipa_user: "{{ sudoers__env_admin_username }}"
+    ipa_pass: "{{ sudoers__env_admin_password }}"
+    name: "{{ sudoers__sudorule_name }}"
+    state: absent
+
+# Remove the FreeIPA group for sudo
+- name: Remove sudoers group
+  community.general.ipa_group:
+    ipa_user: "{{ sudoers__env_admin_username }}"
+    ipa_pass: "{{ sudoers__env_admin_password }}"
+    name: "{{ sudoers__sudo_group_name }}"
+    state: absent
+  register: sudoers_group


### PR DESCRIPTION
2 new roles in:
* **freeipa_host_group** to add the FreeIPA server to a inventory host group (currently just for AWS but with TODOs for GCP & Azure).
* **sudoers** for adding a specified list of users to a FreeIPA group and then creating a sudo rule for that group
