### PR TITLE
Fix AWS not applying tags for ELB for Kubernetes deployments

### DIFF
--- a/roles/infrastructure/tasks/initialize_base.yml
+++ b/roles/infrastructure/tasks/initialize_base.yml
@@ -50,6 +50,7 @@
       cidr: "{{ __public_subnet_item }}"
       tags:
         "kubernetes.io/role/elb": "1"
+        "Name": "{{ [infra__namespace, infra__vpc_public_subnets_suffix, __public_subnet_idx|string] | join('-') }}"
 
 - name: Generate Private Subnet Details
   ansible.builtin.set_fact:
@@ -64,3 +65,4 @@
       cidr: "{{ __private_subnet_item }}"
       tags:
         "kubernetes.io/role/internal-elb": "1"
+        "Name": "{{ [infra__namespace, infra__vpc_private_subnets_suffix, __private_subnet_idx|string] | join('-') }}"

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -52,6 +52,7 @@
   loop_control:
     loop_var: __aws_subnet_create_item
     index_var: __aws_subnet_index
+    label: __aws_subnet_create_item.name
   loop: "{{ infra__vpc_public_subnets_info | union(infra__vpc_private_subnets_info) }}"
   register: __aws_subnets
 

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -44,15 +44,15 @@
   amazon.aws.ec2_vpc_subnet:
     region: "{{ infra__region }}"
     vpc_id: "{{ infra__aws_vpc_id }}"
-    cidr: "{{ __aws_subnet_cidr_item }}"
+    cidr: "{{ __aws_subnet_create_item.cidr }}"
     state: present
-    tags: "{{ infra__tags | combine({ 'Name': infra__namespace }, recursive=True) }}"
+    tags: "{{ infra__tags | combine(__aws_subnet_create_item.tags, recursive=True) }}"
     map_public: yes
     az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
   loop_control:
-    loop_var: __aws_subnet_cidr_item
+    loop_var: __aws_subnet_create_item
     index_var: __aws_subnet_index
-  loop: "{{ infra__vpc_public_subnet_cidrs | union(infra__vpc_private_subnet_cidrs) }}"
+  loop: "{{ infra__vpc_public_subnets_info | union(infra__vpc_private_subnets_info) }}"
   register: __aws_subnets
 
 - name: Set fact for AWS Subnet IDs


### PR DESCRIPTION
Fixes #10
Fix AWS Subnet creation where a config was being generated but had only been applied to Azure and GCP deployments.
Retrofitted correct tags and naming policy to AWS subnet creation. Existing deployments may re-run to gain updated names and tags.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>