### PR TITLE
Fix unused DWX variable and more accurate datahub definition filters

### DIFF
--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -108,14 +108,14 @@
       bucket: "{{ infra__storage_name }}"
       path: "{{ infra__ml_path }}"
     
-- name: Set fact to include DWX data location
+- name: Set fact to include DE data location
   when: infra__de_deploy
   ansible.builtin.set_fact:
     infra__aws_storage_locations: "{{ infra__aws_storage_locations | default([]) | union([storage_location]) }}"
   vars:
     storage_location:
       bucket: "{{ infra__storage_name }}"
-      path: "{{ infra__dwx_path }}"
+      path: "{{ infra__de_path }}"
 
 - name: Set facts for dynamic inventory metadata
   ansible.builtin.set_fact:

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -98,9 +98,9 @@
       cloudera.cloud.datahub_definition_info:
       register: __datahub_definition_info
 
-    - name: Set fact for available CDP Datahub definitions by Datalake version
+    - name: Set fact for available CDP Datahub definitions by Datalake version and Cloud Platform
       ansible.builtin.set_fact:
-        run__datahub_available_definitions: "{{ __datahub_definition_info.definitions | selectattr('productVersion', 'search', run__cdp_datalake_version) | map(attribute='clusterDefinitionName') | list }}"
+        run__datahub_available_definitions: "{{ __datahub_definition_info.definitions | selectattr('productVersion', 'search', run__cdp_datalake_version) | selectattr('cloudPlatform', 'search', run__infra_type.upper()) | map(attribute='clusterDefinitionName') | list }}"
 
     - name: Construct CDP Datahub configurations
       ansible.builtin.set_fact:


### PR DESCRIPTION
Fix reference to unused DWX variable in DE placeholders for new feature
Fix filtering datahub definitions to include version and provider, not just version

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>