### PR TITLE
Changes for DF-beta

### DIFF
--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -78,16 +78,13 @@
 - name: Execute CDP Dataflow setup
   when: run__include_df
   cloudera.cloud.df:
-    name: "{{ run__env_name }}"
+    name: "{{ run__cdp_env_crn }}"
     nodes_min: "{{ run__df_nodes_min }}"
     nodes_max: "{{ run__df_nodes_max }}"
     public_loadbalancer: "{{ run__df_public_loadbalancer }}"
     ip_ranges: "{{ run__df_ip_ranges }}"
     state: present
-    wait: yes
-  async: 3600 # 1 hour timeout
-  poll: 0
-  register: __df_build
+    wait: no
 
 - name: Wait for CDP Datahub deployments to complete
   when: run__include_datahub
@@ -130,9 +127,6 @@
 
 - name: Wait for CDP Dataflow deployment to complete
   when: run__include_df
-  ansible.builtin.async_status:
-    jid: "{{ __df_build.ansible_job_id }}"
-  register: __df_build_async
-  until: __df_build_async.finished
-  retries: 120
-  delay: 30
+  cloudera.cloud.df:
+    name: "{{ run__cdp_env_crn }}"
+    wait: yes

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -56,13 +56,10 @@
 - name: Execute CDP Dataflow teardown
   when: run__include_df
   cloudera.cloud.df:
-    name: "{{ run__env_name }}"
+    name: "{{ run__cdp_env_crn }}"
     persist: "{{ run__df_persist }}"
     state: absent
-    wait: yes
-  async: 3600 # 1 hour timeout
-  poll: 0
-  register: __df_teardown_info
+    wait: no
 
 - name: Execute CDP ML Workspace teardown
   when: run__include_ml
@@ -132,9 +129,8 @@
 
 - name: Wait for CDP Dataflow deployment to decommission
   when: run__include_df
-  ansible.builtin.async_status:
-    jid: "{{ __df_teardown_info.ansible_job_id }}"
-  register: __df_teardown_async
-  until: __df_teardown_async.finished
-  retries: 120
-  delay: 30
+  cloudera.cloud.df:
+    name: "{{ run__cdp_env_crn }}"
+    persist: "{{ run__df_persist }}"
+    state: absent
+    wait: yes

--- a/roles/sequence/defaults/main.yml
+++ b/roles/sequence/defaults/main.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-sequence__setup_runtime:  "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined | default(False) | bool }}"
+sequence__setup_runtime:  "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) | bool }}"
 
 sequence__setup_plat:     "{{ env is defined or sequence__setup_runtime  | default(False) | bool }}"
 


### PR DESCRIPTION
Dependent on https://github.com/cloudera-labs/cloudera.cloud/pull/17
Dependent on https://github.com/cloudera-labs/cdpy/pull/21

Add df key to sequence role to handle deploying to defaults when only df is requested
Switch request to use Environment crn instead of name for better determinism when user supplies unexpected values
Switch from async call to direct call for df enable / disable as it is a 1:1 mapping to environment

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>