### PR TITLE
Create environments on existing AWS networking setup

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -244,6 +244,11 @@ infra:
         private_route_table:
         public_route_table_suffix:
         private_route_table_suffix:
+      existing:
+        vpcId:
+        public_subnet_ids:
+        private_subnet_ids:
+        onprem_cidrs_for_security_groups:
   azure:
     metagroup:
       name:

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -29,6 +29,7 @@ infra__vpc_public_subnets_suffix:   "{{ common__vpc_public_subnets_suffix }}"
 # Infra
 infra__type:                        "{{ common__infra_type }}"
 infra__tunnel:                      "{{ common__tunnel }}"
+infra__public_endpoint_access:      "{{ common__public_endpoint_access }}"
 
 # Dynamic Inventory for Clusters
 infra__private_key_file:                 "{{ globals.ssh.private_key_file | default('') }}"
@@ -76,6 +77,11 @@ infra__vpc_extra_ports:             "{{ infra.vpc.extra_ports | default([22, 443
 infra__vpc_extra_cidr:              "{{ infra.vpc.extra_cidr | default([]) }}"
 infra__vpc_user_ports:              "{{ infra.vpc.user_ports | default([infra__all_ports_security_rule[infra__type]]) }}"
 infra__vpc_user_cidr:               "{{ infra.vpc.user_cidr | default([]) }}"
+
+infra__aws_vpc_id:                  "{{ infra.aws.vpc.existing.vpcId | default('') }}"
+infra__aws_public_subnet_ids:       "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
+infra__aws_private_subnet_ids:      "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
+infra__aws_onprem_cidrs:            "{{ infra.aws.vpc.existing.onprem_cidrs_for_security_groups | default([]) }}"
 
 infra__security_group_knox_name:    "{{ common__security_group_knox_name }}"
 infra__security_group_default_name: "{{ common__security_group_default_name }}"

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -29,28 +29,31 @@
     - bucket: "{{ infra__storage_name }}"
       path: "{{ infra__ranger_audit_path }}"
 
-- name: Query AWS VPCs by unique name and CIDR
-  amazon.aws.ec2_vpc_net_info:
-    region: "{{ infra__region }}"
-    filters:
-      "tag:Name": "{{ infra__vpc_name }}*"
-      cidr: "{{ infra__vpc_cidr }}"
-  register: __aws_vpc_list
+- name: Fetch the AWS VPC id
+  when: infra__aws_vpc_id == ""
+  block:
+    - name: Query AWS VPCs by unique name and CIDR
+      amazon.aws.ec2_vpc_net_info:
+        region: "{{ infra__region }}"
+        filters:
+          "tag:Name": "{{ infra__vpc_name }}*"
+          cidr: "{{ infra__vpc_cidr }}"
+      register: __aws_vpc_list
 
-- name: Check VPC list for singular response
-  when: __aws_vpc_list.vpcs | count > 1
-  ansible.builtin.fail:
-    msg: "Found more than one VPC matching name and CIDR"
+    - name: Check VPC list for singular response
+      when: __aws_vpc_list.vpcs | count > 1
+      ansible.builtin.fail:
+        msg: "Found more than one VPC matching name and CIDR"
 
-- name: Set fact for AWS VPC ID parameter on a unique response
-  when: __aws_vpc_list.vpcs | count == 1
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: "{{ __aws_vpc_list.vpcs[0].vpc_id }}"
+    - name: Set fact for AWS VPC ID parameter on a unique response
+      when: __aws_vpc_list.vpcs | count == 1
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_list.vpcs[0].vpc_id }}"
 
-- name: Reset and set fact for AWS VPC ID if none found
-  when: __aws_vpc_list.vpcs | count < 1
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: ""
+    - name: Reset and set fact for AWS VPC ID if none found
+      when: __aws_vpc_list.vpcs | count < 1
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: ""
 
 - name: Fetch EC2 Instance info for Dynamic Inventory Nodes
   register: __infra_dynamic_inventory_discovered

--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -90,6 +90,19 @@
         ports: "{{ infra__vpc_extra_ports }}"
         cidr_ip: "{{ infra__vpc_extra_cidr }}"
 
+- name: Prepare AWS Security Group Rules for on-prem based setups.
+  when: infra__tunnel
+  ansible.builtin.set_fact:
+    infra__aws_security_group_rules: "{{ infra__aws_security_group_rules | union([rule]) }}"
+  loop_control:
+    loop_var: __onprem_cidr
+  loop: "{{ infra__aws_onprem_cidrs }}"
+  vars:
+    rule:
+      proto: all
+      ports: 0-65535
+      cidr_ip: "{{ __onprem_cidr }}"
+
 - name: Add CDP Public Cloud security group rules for AWS
   when: not infra__tunnel
   ansible.builtin.set_fact:

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -14,85 +14,87 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create AWS VPC
-  amazon.aws.ec2_vpc_net:
-    region: "{{ infra__region }}"
-    name: "{{ infra__vpc_name }}"
-    cidr_block: "{{ infra__vpc_cidr }}"
-    tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
-    state: present
-  register: __aws_vpc_info
+- name: Set up AWS Network Infrastructure if not provided
+  when: infra__aws_subnet_ids is undefined
+  block:
+    - name: Create AWS VPC
+      amazon.aws.ec2_vpc_net:
+        region: "{{ infra__region }}"
+        name: "{{ infra__vpc_name }}"
+        cidr_block: "{{ infra__vpc_cidr }}"
+        tags: "{{ infra__tags }}" # TODO - Filter out name, per module warning
+        state: present
+      register: __aws_vpc_info
 
-- name: Set fact for AWS VPC ID
-  ansible.builtin.set_fact:
-    infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
+    - name: Set fact for AWS VPC ID
+      ansible.builtin.set_fact:
+        infra__aws_vpc_id: "{{ __aws_vpc_info.vpc.id }}"
 
-- name: Create IGW 
-  community.aws.ec2_vpc_igw:
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    region: "{{ infra__region }}"
-    state: present
-    tags: "{{ infra__tags | combine({ 'Name': infra__aws_igw_name }, recursive=True) }}"
-  register: __aws_igw
+    - name: Create IGW
+      community.aws.ec2_vpc_igw:
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        region: "{{ infra__region }}"
+        state: present
+        tags: "{{ infra__tags | combine({ 'Name': infra__aws_igw_name }, recursive=True) }}"
+      register: __aws_igw
 
-- name: Set fact for IGW ID
-  when: __aws_igw.gateway_id is defined
-  ansible.builtin.set_fact:
-    infra__aws_igw_id: "{{ __aws_igw.gateway_id }}"
+    - name: Set fact for IGW ID
+      when: __aws_igw.gateway_id is defined
+      ansible.builtin.set_fact:
+        infra__aws_igw_id: "{{ __aws_igw.gateway_id }}"
 
-- name: Create AWS VPC Public Subnets
-  amazon.aws.ec2_vpc_subnet:
-    region: "{{ infra__region }}"
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    cidr: "{{ __aws_public_subnet_item.cidr }}"
-    state: present
-    tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive = true) }}"
-    map_public: yes
-    az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
-  loop_control:
-    loop_var: __aws_public_subnet_item
-    index_var: __aws_subnet_index
-  loop: "{{ infra__vpc_public_subnets_info }}"
-  register: __aws_public_subnets
+    - name: Create AWS VPC Public Subnets
+      amazon.aws.ec2_vpc_subnet:
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        cidr: "{{ __aws_public_subnet_item.cidr }}"
+        state: present
+        tags: "{{ infra__tags | combine(__aws_public_subnet_item.tags, recursive = true) }}"
+        map_public: yes
+        az: "{{ __aws_az_info.availability_zones[__aws_subnet_index % infra__aws_vpc_az_count | int].zone_name }}"
+      loop_control:
+        loop_var: __aws_public_subnet_item
+        index_var: __aws_subnet_index
+      loop: "{{ infra__vpc_public_subnets_info }}"
+      register: __aws_public_subnets
 
-- name: Set fact for AWS Public Subnet IDs
-  ansible.builtin.set_fact:
-    infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids | default([]) | union([__aws_subnet_item.subnet.id | default('')]) }}"
-  loop_control:
-    loop_var: __aws_subnet_item
-    label: "{{ __aws_subnet_item.subnet.id }}"
-  loop: "{{ __aws_public_subnets.results }}"
+    - name: Set fact for AWS Public Subnet IDs
+      ansible.builtin.set_fact:
+        infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids | default([]) | union([__aws_subnet_item.subnet.id | default('')]) }}"
+      loop_control:
+        loop_var: __aws_subnet_item
+      loop: "{{ __aws_public_subnets.results }}"
 
-- name: List the Route Tables for the VPC
-  community.aws.ec2_vpc_route_table_info:
-    region: "{{ infra__region }}"
-    filters:
-      vpc-id: "{{ infra__aws_vpc_id }}"
-  register: __aws_route_table_list
+    - name: List the Route Tables for the VPC
+      community.aws.ec2_vpc_route_table_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+      register: __aws_route_table_list
 
-- name: Configure the Public Route Table
-  community.aws.ec2_vpc_route_table:
-    region: "{{ infra__region }}"
-    vpc_id: "{{ infra__aws_vpc_id }}"
-    route_table_id: "{{ __aws_route_table_id }}"
-    lookup: id
-    state: present
-    tags: "{{ infra__tags | combine({ 'Name': infra__aws_public_route_table_name }, recursive=True) }}"
-    routes:
-      - dest: "0.0.0.0/0"
-        gateway_id: "{{ infra__aws_igw_id }}"
-    subnets: "{{ infra__aws_public_subnet_ids }}"
-  vars:
-    __aws_route_table_id: "{{ __aws_route_table_list.route_tables | json_query(__aws_rtb_jq) | flatten | first }}"
-    __aws_rtb_jq: "[*].associations[?main == `true` ].route_table_id"
+    - name: Configure the Public Route Table
+      community.aws.ec2_vpc_route_table:
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        route_table_id: "{{ __aws_route_table_id }}"
+        lookup: id
+        state: present
+        tags: "{{ infra__tags | combine({ 'Name': infra__aws_public_route_table_name }, recursive=True) }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: "{{ infra__aws_igw_id }}"
+        subnets: "{{ infra__aws_public_subnet_ids }}"
+      vars:
+        __aws_route_table_id: "{{ __aws_route_table_list.route_tables | json_query(__aws_rtb_jq) | flatten | first }}"
+        __aws_rtb_jq: "[*].associations[?main == `true` ].route_table_id"
 
-- name: Set the fact for Subnet Ids
-  when: not infra__tunnel
-  ansible.builtin.set_fact:
-    infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+    - name: Set the fact for Subnet Ids
+      when: not infra__tunnel
+      ansible.builtin.set_fact:
+        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
 
-- name: Setup for private networking
-  when: infra__tunnel
+- name: Setup for private networking when tunneling is enabled for a new infra setup.
+  when: infra__tunnel and (infra__aws_subnet_ids is undefined)
   block:
     - name: Create AWS VPC Private Subnets
       amazon.aws.ec2_vpc_subnet:
@@ -116,10 +118,6 @@
       loop_control:
         loop_var: __aws_subnet_item
       loop: "{{ __aws_private_subnets.results }}"
-
-    - name: Set fact for Subnet Ids
-      ansible.builtin.set_fact:
-        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
 
     - name: Creates NAT gateways and allocates EIPs
       community.aws.ec2_vpc_nat_gateway:
@@ -148,6 +146,10 @@
         loop_var: __aws_private_subnet_id_item
         index_var: __aws_private_subnet_id_index
       loop: "{{ infra__aws_private_subnet_ids }}"
+
+    - name: Set fact for Subnet Ids
+      ansible.builtin.set_fact:
+        infra__aws_subnet_ids: "{{ infra__aws_public_subnet_ids | union(infra__aws_private_subnet_ids) }}"
 
 - name: Create Security Groups
   amazon.aws.ec2_group:

--- a/roles/infrastructure/tasks/validate_aws.yml
+++ b/roles/infrastructure/tasks/validate_aws.yml
@@ -29,3 +29,57 @@
 
 - name: Print AWS Profile to debug
   ansible.builtin.command: echo AWS_PROFILE is $AWS_PROFILE
+
+- name: Validate the vpcId and subnet Ids if provided for a private network
+  when: infra__aws_vpc_id != ""
+  block:
+  - name: Validate the vpc Id
+    amazon.aws.ec2_vpc_net_info:
+      vpc_ids: "{{ infra__aws_vpc_id }}"
+    register: __aws_vpc_list
+    failed_when: __aws_vpc_list.vpcs is undefined
+
+  - name: Check for non-empty private subnets list
+    when: infra__aws_private_subnet_ids | unique | count < 3
+    ansible.builtin.fail:
+      msg: "At least 3 private subnets need to be provided."
+
+  - name: Fetch the private subnets info.
+    amazon.aws.ec2_vpc_subnet_info:
+      subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+    register: __aws_private_subnets_info
+
+  - name: Derive the number of AZs the private subnets belong to
+    set_fact:
+      __private_subnets_azs_count : "{{ __aws_private_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count }}"
+
+  - name: Validate the Private Subnets
+    when: (__private_subnets_azs_count < infra__aws_vpc_az_count) or
+          (True in (__aws_private_subnets_info.subnets | map(attribute='map_public_ip_on_launch')))
+    ansible.builtin.fail:
+      msg: "The private subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
+
+  - name: Check for non-empty public subnets list
+    when: infra__public_endpoint_access and ((infra__aws_public_subnet_ids | unique | count) < (__private_subnets_azs_count | int))
+    ansible.builtin.fail:
+      msg: "There should be at least as many public subnets as the numbers of AZs the input private subnets reside in."
+
+  - name: Fetch the public subnets info.
+    when: infra__public_endpoint_access
+    amazon.aws.ec2_vpc_subnet_info:
+      subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+    register: __aws_public_subnets_info
+
+  - name: Validate the Public Subnet
+    when: infra__public_endpoint_access and
+          (__aws_public_subnets_info.subnets | map(attribute='availability_zone') | list | unique | count < (__private_subnets_azs_count | int))
+    ansible.builtin.fail:
+      msg: "The public subnets should be provided from at least 2 AZs and should have public IP addressing disabled"
+
+  # Set the facts for subsequent plays to pick them up.
+  - name: Set fact for VPC Id and subnet Ids.
+    ansible.builtin.set_fact:
+      infra__aws_vpc_id: "{{ infra__aws_vpc_id }}"
+      infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
+      infra__aws_subnet_ids: "{{ infra__aws_private_subnet_ids }}"
+      infra__vpc_cidr: "{{ __aws_vpc_list.vpcs[0].cidr_block }}"


### PR DESCRIPTION
**Work in Progress**

The PR introduces a few extra fields:

infra:
  teardown:
    delete_network: false
  aws:
    vpc:
      existing:
       vpcId: "vpc-0966cbdb18b658ecd"
        private_subnet_ids:
          - "subnet-123"
        public_subnet_ids:
          - "subnet-456"
        onprem_cidrs_for_security_groups:
          - "10.xx.xx.xx/yy"


Ideal for setups on private networks. We can provide a VPC and subnets peered with an on-prem network and the play uses these details to setup the environment.

onprem_cidrs_for_security_groups is meant to capture the on-prem cidrs so as to add them to the security groups allowingg seamless access between CDP environments and on-prem networks. Alternately, the CIDRs can be added manually on AWS once the setup is complete.