### PR TITLE
Fix default opdb teardown

### DIFF
--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -38,7 +38,7 @@
   loop_control:
     loop_var: __opdb_config
     label: "{{ __opdb_config.name | default('opdb') }}"
-  loop: "{{ run__opdb_definitions }}"
+  loop: "{{ run__opdb_configs }}"
   async: 3600 # 1 hour timeout
   poll: 0
   register: __opdb_teardowns_info


### PR DESCRIPTION
opdb teardown not using initialized configs resulting in a failure when no name is specified in the default. This now matches the common pattern

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>