### PR TITLE
Improve teardown and support purge mode, other minor fixes

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -134,4 +134,4 @@ common__include_datahub:                   "{{ datahub is defined | bool }}"
 common__include_opdb:                      "{{ opdb is defined | bool }}"
 
 # Teardown
-common__force_teardown:                    "{{ purge | default(False) }}"  # WARNING: This will purge your namespace and anything related to it, use with extreme caution
+common__force_teardown:                    "{{ globals.force_teardown | default(False) }}"  # WARNING: This will purge your namespace and anything related to it, use with extreme caution

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -132,3 +132,6 @@ common__include_de:                        "{{ de is defined | bool }}"
 common__include_df:                        "{{ df is defined | bool }}"
 common__include_datahub:                   "{{ datahub is defined | bool }}"
 common__include_opdb:                      "{{ opdb is defined | bool }}"
+
+# Teardown
+common__force_teardown:                    "{{ purge | default(False) }}"  # WARNING: This will purge your namespace and anything related to it, use with extreme caution

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -129,3 +129,7 @@ infra__cdp_control_plane_cidr:      "{{ env.cdp.control_plane.cidr | default(inf
 # Utility Service for Download Mirror
 infra__create_utility_service:      "{{ globals.create_utility_service | default('no') | bool }}"
 infra__utlity_bucket_name:          "{{ globals.utility_bucket_name | default('') }}"
+
+# Teardown
+infra__force_teardown:              "{{ common__force_teardown }}"
+infra__env_name:                    "{{ common__env_name }}"  # Used for purge lookups

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -89,3 +89,132 @@
   ansible.builtin.set_fact:
     infra__type: "{{ infra__type }}"
     infra__region: "{{ infra__region }}"
+
+- name: Discover VPC Dependencies during Purge cleanup
+  when:
+    - infra__force_teardown | bool
+    - infra__aws_vpc_id | length > 1
+  block:
+    - name: Fetch Network Interfaces in VPC
+      register: __infra_vpc_enis
+      amazon.aws.ec2_eni_info:
+        region: "{{ infra__region }}"
+        filters: "{{ __filters | items2dict }}"
+      vars:
+        __filters:
+          - key: "vpc-id"
+            value: "{{ infra__aws_vpc_id }}"
+
+    - name: List all EC2 instances in VPC
+      register: __infra_vpc_ec2_instances
+      community.aws.ec2_instance_info:
+        region: "{{ infra__region }}"
+        filters: "{{ __filters | items2dict }}"
+      vars:
+        __filters:
+          - key: "vpc-id"
+            value: "{{ infra__aws_vpc_id }}"
+
+    - name: Update discovered compute inventory for later action
+      ansible.builtin.set_fact:
+        infra__discovered_compute_inventory: "{{ infra__discovered_compute_inventory + __infra_vpc_ec2_instances.instances }}"
+
+    - name: List EKS Clusters
+      register: __infra_eks_cluster_list
+      command: "aws eks list-clusters"
+
+    - name: Describe all EKS Clusters
+      register: __infra_eks_cluster_details
+      ansible.builtin.command: "aws eks describe-cluster --name {{ __infra_eks_cluster_item }}"
+      loop_control:
+        loop_var: __infra_eks_cluster_item
+      loop: "{{ __infra_eks_cluster_list.stdout | from_json | community.general.json_query('clusters') }} "
+
+    - name: Filter EKS by this VPC
+      ansible.builtin.set_fact:
+        __infra_vpc_eks_cluster_names: "{{ __infra_vpc_eks_cluster_names | d([]) + [__infra_lookup_name] }}"
+      when: __infra_lookup_vpc == infra__aws_vpc_id
+      vars:
+        __infra_lookup_vpc: "{{ __infra_eks_cluster_detail_item.stdout | from_json | community.general.json_query('cluster.resourcesVpcConfig.vpcId') }}"
+        __infra_lookup_name: "{{ __infra_eks_cluster_detail_item.stdout | from_json | community.general.json_query('cluster.name') }}"
+      loop: "{{ __infra_eks_cluster_details.results }}"
+      loop_control:
+        loop_var: __infra_eks_cluster_detail_item
+
+    - name: List all ASGs in region
+      register: __infra_ec2_asg_list
+      community.aws.ec2_asg_info:
+        region: "{{ infra__region }}"
+
+    - name: Fetch list of all Subnets in VPC
+      register: __infra_disc_subnets
+      amazon.aws.ec2_vpc_subnet_info:
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+
+    - name: Filter ASGs by Subnets in this VPC
+      when:
+        - __infra_ec2_asg_list.results | length > 0
+        - __infra_asg_filter_item.vpc_zone_identifier in __infra_vpc_subnet_ids
+      ansible.builtin.set_fact:
+        __infra_aws_asg_names: "{{ __infra_aws_asg_names | default([]) + [__infra_asg_filter_item.auto_scaling_group_name] }}"
+      vars:
+        __infra_vpc_subnet_ids: "{{ __infra_disc_subnets.subnets | community.general.json_query('[*].id') | list | unique }}"
+        __infra_vpc_sg_ids: "{{ __infra_disc_sgs.security_groups | community.general.json_query('[*].group_id') | list | unique }}"
+      loop: "{{ __infra_ec2_asg_list.results }}"
+      loop_control:
+        loop_var: __infra_asg_filter_item
+
+    - name: List all AWS ELBs in region
+      community.aws.ec2_elb_info:
+        region: "{{ infra__region }}"
+      register: __infra_ec2_elbs
+
+    - name: Filter list of ELBS to match our VPC
+      when:
+        - __infra_ec2_elbs.elbs | length > 0
+        - __infra_ec2_elb_item.vpc_id == infra__aws_vpc_id
+      ansible.builtin.set_fact:
+        __infra_ec2_elb_names: "{{ __infra_ec2_elb_names | default([]) + [__infra_ec2_elb_item.name] }}"
+      loop: "{{ __infra_ec2_elbs.elbs }}"
+      loop_control:
+        loop_var: __infra_ec2_elb_item
+
+    - name: List NAT gatways in VPC
+      community.aws.ec2_vpc_nat_gateway_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+      register: __infra_aws_nat_gateways
+
+    - name: List all Security Groups in VPC
+      register:  __infra_aws_sgs
+      amazon.aws.ec2_group_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+
+    - name: List all Route tables in VPC
+      register: __infra_aws_rtbs
+      community.aws.ec2_vpc_route_table_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+
+- name: Discover Storage during Purge cleanup
+  when:
+    - infra__force_teardown | bool
+  block:
+    - name: List AWS EBS Volumes
+      register: __infra_aws_ebs_vols
+      amazon.aws.ec2_vol_info:
+        region: "{{ infra__region }}"
+        filters:
+          status: available
+
+    - name: Check for Orphaned EFS matching Namespace
+      register: __infra_efs_fs
+      community.aws.efs_info:
+        region: "{{ infra__region }}"
+        tags:
+          Environment: "{{ infra__env_name }}"

--- a/roles/infrastructure/tasks/initialize_azure.yml
+++ b/roles/infrastructure/tasks/initialize_azure.yml
@@ -51,10 +51,10 @@
 
 - name: Set Azure Caller Information
   ansible.builtin.set_fact:
-    infra__azure_subscription_id: "{{ __azure_account_info.stdout | from_json | json_query('id') }}"
-    infra__azure_subscription_name: "{{ __azure_account_info.stdout | from_json | json_query('name') }}"
-    infra__azure_tenant_id: "{{ __azure_account_info.stdout | from_json | json_query('tenantId') }}"
-    infra__azure_calling_user: "{{ __azure_account_info.stdout | from_json | json_query('user.name') }}"
+    infra__azure_subscription_id: "{{ __azure_account_info.stdout | from_json | community.general.json_query('id') }}"
+    infra__azure_subscription_name: "{{ __azure_account_info.stdout | from_json | community.general.json_query('name') }}"
+    infra__azure_tenant_id: "{{ __azure_account_info.stdout | from_json | community.general.json_query('tenantId') }}"
+    infra__azure_calling_user: "{{ __azure_account_info.stdout | from_json | community.general.json_query('user.name') }}"
 
 - name: Print Azure Account Info
   ansible.builtin.debug:

--- a/roles/infrastructure/tasks/setup_aws_storage.yml
+++ b/roles/infrastructure/tasks/setup_aws_storage.yml
@@ -14,6 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Warn user about HeadBucket Forbidden errors
+  debug:
+    msg: >
+    "If the 'Create AWS Buckets' task below fails with HeadBucket Forbidden errors,
+    your bucket name is in use in another AWS account and you should use a different name_prefix"
+
 - name: Create AWS Buckets
   amazon.aws.aws_s3:
     region: "{{ infra__region }}"

--- a/roles/infrastructure/tasks/setup_aws_storage.yml
+++ b/roles/infrastructure/tasks/setup_aws_storage.yml
@@ -16,9 +16,10 @@
 
 - name: Warn user about HeadBucket Forbidden errors
   debug:
-    msg: >
-    "If the 'Create AWS Buckets' task below fails with HeadBucket Forbidden errors,
-    your bucket name is in use in another AWS account and you should use a different name_prefix"
+    msg:
+      - "If the 'Create AWS Buckets' task below fails. "
+      - "If you see HeadBucket Forbidden errors. "
+      - "Your bucket name is probably use in another AWS account and you should use a different name_prefix"
 
 - name: Create AWS Buckets
   amazon.aws.aws_s3:

--- a/roles/infrastructure/tasks/setup_azure_network.yml
+++ b/roles/infrastructure/tasks/setup_azure_network.yml
@@ -48,8 +48,8 @@
 
 - name: Set fact for Azure Security Group IDs
   ansible.builtin.set_fact:
-    infra__azure_security_group_knox_uri: "{{ __azure_security_group_info | json_query(knox) | first }}"
-    infra__azure_security_group_default_uri: "{{ __azure_security_group_info | json_query(default) | first }}"
+    infra__azure_security_group_knox_uri: "{{ __azure_security_group_info | community.general.json_query(knox) | first }}"
+    infra__azure_security_group_default_uri: "{{ __azure_security_group_info | community.general.json_query(default) | first }}"
   vars:
     knox: "results[?__azure_network_security_group_name_item=='{{ infra__security_group_knox_name }}'].state.id"
     default: "results[?__azure_network_security_group_name_item=='{{ infra__security_group_default_name }}'].state.id"

--- a/roles/infrastructure/tasks/teardown_aws_compute.yml
+++ b/roles/infrastructure/tasks/teardown_aws_compute.yml
@@ -26,7 +26,6 @@
   loop_control:
     loop_var: __infra_asg_remove_item
 
-# TODO: Make async
 - name: Handle EKS Cluster removal if discovered
   when:
     - infra__force_teardown | bool
@@ -39,6 +38,24 @@
   loop: "{{ __infra_vpc_eks_cluster_names }}"
   loop_control:
     loop_var: __infra_eks_remove_item
+  async: 3600 # 1 hour timeout
+  poll: 0
+  register: __eks_teardowns_info
+
+- name: Wait for EKS teardowns to complete
+  when:
+    - __eks_teardowns_info is defined
+    - __eks_teardowns_info.results is defined
+    - __eks_teardowns_info.results | length > 0
+  ansible.builtin.async_status:
+    jid: "{{ __eks_teardown.ansible_job_id }}"
+  loop_control:
+    loop_var: __eks_teardown
+  loop: "{{ __eks_teardowns_info.results }}"
+  register: __eks_teardowns_async
+  until: __eks_teardowns_async.finished
+  retries: 120
+  delay: 10
 
 - name: Handle Compute Removal if Discovered
   when: infra__discovered_compute_inventory | count > 0

--- a/roles/infrastructure/tasks/teardown_aws_compute.yml
+++ b/roles/infrastructure/tasks/teardown_aws_compute.yml
@@ -14,10 +14,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Handle EC2 Autoscaling Groups removal if discovered
+  when:
+    - infra__force_teardown | bool
+    - __infra_aws_asg_names is defined
+    - __infra_aws_asg_names | length > 0
+  community.aws.ec2_asg:
+    name: "{{ __infra_asg_remove_item }}"
+    state: absent
+  loop: "{{ __infra_aws_asg_names }}"
+  loop_control:
+    loop_var: __infra_asg_remove_item
+
+# TODO: Make async
+- name: Handle EKS Cluster removal if discovered
+  when:
+    - infra__force_teardown | bool
+    - __infra_vpc_eks_cluster_names is defined
+    - __infra_vpc_eks_cluster_names | length > 0
+  community.aws.aws_eks_cluster:
+    name: "{{ __infra_eks_remove_item }}"
+    wait: yes
+    state: absent
+  loop: "{{ __infra_vpc_eks_cluster_names }}"
+  loop_control:
+    loop_var: __infra_eks_remove_item
+
 - name: Handle Compute Removal if Discovered
   when: infra__discovered_compute_inventory | count > 0
   amazon.aws.ec2:
     region: "{{ infra__region }}"
     wait: yes
     state: absent
-    instance_ids: "{{ infra__discovered_compute_inventory | community.general.json_query('[*].instance_id') | list }}"
+    instance_ids: "{{ infra__discovered_compute_inventory | community.general.json_query('[*].instance_id') | list | unique }}"

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -17,7 +17,50 @@
 - name: Tear down AWS Network
   when: infra__aws_vpc_id | length > 1 and infra__teardown_deletes_network
   block:
-    - name: Remove Security Groups
+    - name: Remove Elastic Load Balancers, if Discovered
+      when:
+        - __infra_ec2_elb_names is defined
+        - __infra_ec2_elb_names | length > 0
+        - infra__force_teardown | bool
+      loop: "{{ __infra_ec2_elb_names }}"
+      loop_control:
+        loop_var: __infra_elb_remove_item
+      amazon.aws.ec2_elb_lb:
+        name: "{{ __infra_elb_remove_item }}"
+        state: absent
+        wait: yes
+      async: 3600 # 1 hour timeout
+      poll: 0
+      register: __elb_teardowns_info
+
+    - name: Wait for ELB teardowns to complete
+      when:
+        - __elb_teardowns_info is defined
+        - __elb_teardowns_info.results is defined
+        - __elb_teardowns_info.results | length > 0
+      ansible.builtin.async_status:
+        jid: "{{ __elb_teardown.ansible_job_id }}"
+      loop_control:
+        loop_var: __elb_teardown
+      loop: "{{ __elb_teardowns_info.results }}"
+      register: __elb_teardowns_async
+      until: __elb_teardowns_async.finished
+      retries: 120
+      delay: 10
+
+    - name: Remove Network Adapters, if exists
+      when:
+        - __infra_vpc_enis is defined
+        - __infra_vpc_enis.network_interfaces | length > 0
+        - infra__force_teardown | bool
+      amazon.aws.ec2_eni:
+        eni_id: "{{ __eni_adapter.id }}"
+        state: absent
+      loop_control:
+        loop_var: __eni_adapter
+      loop: "{{ __infra_vpc_enis.network_interfaces }}"
+
+    - name: Remove Expected Security Groups
       amazon.aws.ec2_group:
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
@@ -28,6 +71,39 @@
       loop:
         - "{{ infra__security_group_knox_name }}"
         - "{{ infra__security_group_default_name }}"
+
+    - name: Handle Security Groups during Purge
+      when:
+        - __infra_aws_sgs is defined
+        - __infra_aws_sgs.security_groups | length > 0
+        - infra__force_teardown | bool
+      block:
+        - name: Clean Security Group rules during Purge
+          when: __security_group_rule_item.group_name != 'default'
+          amazon.aws.ec2_group:
+            region: "{{ infra__region }}"
+            vpc_id: "{{ infra__aws_vpc_id }}"
+            name: "{{ __security_group_rule_item.group_name }}"
+            description: "{{ __security_group_rule_item.description }}"
+            state: present
+            rules: []
+            rules_egress: []
+          loop_control:
+            loop_var: __security_group_rule_item
+            label: "{{ __security_group_rule_item.group_name }}"
+          loop: "{{ __infra_aws_sgs.security_groups }}"
+
+        - name: Remove Security groups during Purge
+          when: __security_group_purge_item.group_name != 'default'
+          amazon.aws.ec2_group:
+            region: "{{ infra__region }}"
+            vpc_id: "{{ infra__aws_vpc_id }}"
+            name: "{{ __security_group_purge_item.group_name }}"
+            state: absent
+          loop_control:
+            loop_var: __security_group_purge_item
+            label: "{{ __security_group_purge_item.group_name }}"
+          loop: "{{ __infra_aws_sgs.security_groups }}"
 
     - name: Remove the private networking setup
       when: infra__tunnel
@@ -70,6 +146,24 @@
           failed_when: item.rc is defined and item.rc != 1 and ('InvalidAllocationID.NotFound' in item.module_stderr)
           loop: "{{ __aws_ngw_teardown.results }}"
 
+    - name: Remove any NAT Gateways Discovered during Purge
+      register: __infra_aws_nat_remove_result
+      when:
+        - __infra_aws_nat_gateways is defined
+        - __infra_aws_nat_gateways.result | length > 0
+        - infra__force_teardown | bool
+      community.aws.ec2_vpc_nat_gateway:
+        state: absent
+        region: "{{ infra__region }}"
+        wait: true
+        nat_gateway_id: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
+        release_eip: true
+      loop_control:
+        label: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
+        loop_var: __infra_nat_gateway_remove_item
+      loop: "{{ __infra_aws_nat_gateways.result }}"
+      failed_when: __infra_aws_nat_remove_result.rc != 0 and 'InvalidAllocationID.NotFound' not in __infra_aws_nat_remove_result.module_stderr
+
     - name: Remove VPC subnets
       amazon.aws.ec2_vpc_subnet:
         region: "{{ infra__region }}"
@@ -88,6 +182,23 @@
         state: absent
         tags:
           Name: "{{ infra__aws_igw_name }}"
+
+    - name: Remove Route Tables
+      when:
+        - __infra_aws_rtbs is defined
+        - __infra_aws_rtbs.route_tables | length > 0
+        - infra__force_teardown | bool
+        - __infra_aws_rtb_item.associations | selectattr('main', 'equalto', True) | length == 0
+      loop: "{{ __infra_aws_rtbs.route_tables }}"
+      loop_control:
+        loop_var: __infra_aws_rtb_item
+        label: "{{ __infra_aws_rtb_item.id }}"
+      community.aws.ec2_vpc_route_table:
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        region: "{{ infra__region }}"
+        route_table_id: "{{ __infra_aws_rtb_item.id }}"
+        lookup: id
+        state: absent
 
     - name: Remove VPC, if exists
       amazon.aws.ec2_vpc_net:

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -48,6 +48,47 @@
       retries: 120
       delay: 10
 
+    - name: Remove the private networking setup
+      when: infra__tunnel
+      block:
+        - name: Delete the private route tables
+          community.aws.ec2_vpc_route_table:
+            vpc_id: "{{ infra__aws_vpc_id }}"
+            region: "{{ infra__region }}"
+            lookup: tag
+            tags: "{{ { 'Name': '-'.join([infra__aws_private_route_table_name, __aws_private_subnet_id_index | string])} }}"
+            state: absent
+          loop_control:
+            index_var: __aws_private_subnet_id_index
+          loop: "{{ infra__vpc_private_subnet_cidrs }}"
+
+        - name: List all managed nat gateways within this VPC
+          community.aws.ec2_vpc_nat_gateway_info:
+            region: "{{ infra__region }}"
+            filters:
+              vpc-id: "{{ infra__aws_vpc_id }}"
+          register: __aws_all_ngws
+
+        - name: Delete nat gateway using discovered nat gateways from facts module.
+          community.aws.ec2_vpc_nat_gateway:
+            state: absent
+            region: "{{ infra__region }}"
+            wait: true
+            nat_gateway_id: "{{ item.nat_gateway_id }}"
+            release_eip: true
+          register: __aws_ngw_teardown
+          loop_control:
+            label: "{{ item.nat_gateway_id }}"
+          loop: "{{ __aws_all_ngws.result }}"
+          ignore_errors: true
+
+        - name: Check if NAT gateways are deleted succesfully
+          when: __aws_ngw_teardown is defined and __aws_ngw_teardown.results is defined and __aws_ngw_teardown.results | count > 0
+          ansible.builtin.fail:
+            msg: "Failed to delete a NAT gateway"
+          failed_when: item.rc is defined and item.rc != 1 and ('InvalidAllocationID.NotFound' in item.module_stderr)
+          loop: "{{ __aws_ngw_teardown.results }}"
+
     - name: Remove Network Adapters, if exists
       when:
         - __infra_vpc_enis is defined
@@ -106,47 +147,6 @@
             loop_var: __security_group_purge_item
             label: "{{ __security_group_purge_item.group_name }}"
           loop: "{{ __infra_aws_sgs.security_groups }}"
-
-    - name: Remove the private networking setup
-      when: infra__tunnel
-      block:
-        - name: Delete the private route tables
-          community.aws.ec2_vpc_route_table:
-            vpc_id: "{{ infra__aws_vpc_id }}"
-            region: "{{ infra__region }}"
-            lookup: tag
-            tags: "{{ { 'Name': '-'.join([infra__aws_private_route_table_name, __aws_private_subnet_id_index | string])} }}"
-            state: absent
-          loop_control:
-            index_var: __aws_private_subnet_id_index
-          loop: "{{ infra__vpc_private_subnet_cidrs }}"
-
-        - name: List all managed nat gateways within this VPC
-          community.aws.ec2_vpc_nat_gateway_info:
-            region: "{{ infra__region }}"
-            filters:
-              vpc-id: "{{ infra__aws_vpc_id }}"
-          register: __aws_all_ngws
-
-        - name: Delete nat gateway using discovered nat gateways from facts module.
-          community.aws.ec2_vpc_nat_gateway:
-            state: absent
-            region: "{{ infra__region }}"
-            wait: true
-            nat_gateway_id: "{{ item.nat_gateway_id }}"
-            release_eip: true
-          register: __aws_ngw_teardown
-          loop_control:
-            label: "{{ item.nat_gateway_id }}"
-          loop: "{{ __aws_all_ngws.result }}"
-          ignore_errors: true
-
-        - name: Check if NAT gateways are deleted succesfully
-          when: __aws_ngw_teardown is defined and __aws_ngw_teardown.results is defined and __aws_ngw_teardown.results | count > 0
-          ansible.builtin.fail:
-            msg: "Failed to delete a NAT gateway"
-          failed_when: item.rc is defined and item.rc != 1 and ('InvalidAllocationID.NotFound' in item.module_stderr)
-          loop: "{{ __aws_ngw_teardown.results }}"
 
     - name: Remove any NAT Gateways Discovered during Purge
       register: __infra_aws_nat_remove_result

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -51,6 +51,7 @@
     - name: Remove Network Adapters, if exists
       when:
         - __infra_vpc_enis is defined
+        - __infra_vpc_enis.network_interfaces is defined
         - __infra_vpc_enis.network_interfaces | length > 0
         - infra__force_teardown | bool
       amazon.aws.ec2_eni:
@@ -75,6 +76,7 @@
     - name: Handle Security Groups during Purge
       when:
         - __infra_aws_sgs is defined
+        - __infra_aws_sgs.security_groups is defined
         - __infra_aws_sgs.security_groups | length > 0
         - infra__force_teardown | bool
       block:
@@ -150,6 +152,7 @@
       register: __infra_aws_nat_remove_result
       when:
         - __infra_aws_nat_gateways is defined
+        - __infra_aws_nat_gateways.result is defined
         - __infra_aws_nat_gateways.result | length > 0
         - infra__force_teardown | bool
       community.aws.ec2_vpc_nat_gateway:
@@ -186,6 +189,7 @@
     - name: Remove Route Tables
       when:
         - __infra_aws_rtbs is defined
+        - __infra_aws_rtbs.route_tables is defined
         - __infra_aws_rtbs.route_tables | length > 0
         - infra__force_teardown | bool
         - __infra_aws_rtb_item.associations | selectattr('main', 'equalto', True) | length == 0

--- a/roles/infrastructure/tasks/teardown_aws_storage.yml
+++ b/roles/infrastructure/tasks/teardown_aws_storage.yml
@@ -30,3 +30,30 @@
     region: "{{ infra__region }}"
     bucket: "{{ infra__utlity_bucket_name }}"
     mode: delete
+
+- name: Remove AWS EFS File Systems, if Discovered during Purge
+  when:
+    - infra__force_teardown | bool
+    - __infra_efs_fs is defined
+    - __infra_efs_fs.efs | length > 0
+  community.aws.efs:
+    state: absent
+    name: "{{ __infra_efs_item.name }}"
+    wait: yes
+  loop:
+    "{{ __infra_efs_fs.efs }}"
+  loop_control:
+    loop_var: __infra_efs_item
+
+- name: Remove Orphaned EBS Volumes during Purge
+  when:
+    - infra__force_teardown | bool
+    - __infra_aws_ebs_vols is defined
+    - __infra_aws_ebs_vols.volumes | length > 0
+    - __infra_aws_ebs_item.attachment_set.status != ""
+  amazon.aws.ec2_vol:
+    id: "{{ __infra_aws_ebs_item.id }}"
+    state: absent
+  loop: "{{ __infra_aws_ebs_vols.volumes }}"
+  loop_control:
+    loop_var: __infra_aws_ebs_item

--- a/roles/platform/tasks/initialize_azure.yml
+++ b/roles/platform/tasks/initialize_azure.yml
@@ -20,10 +20,10 @@
 
 - name: Set Azure Caller Information
   ansible.builtin.set_fact:
-    plat__azure_subscription_id: "{{ __azure_account_info.stdout | from_json | json_query('id') }}"
-    plat__azure_subscription_name: "{{ __azure_account_info.stdout | from_json | json_query('name') }}"
-    plat__azure_tenant_id: "{{ __azure_account_info.stdout | from_json | json_query('tenantId') }}"
-    plat__azure_calling_user: "{{ __azure_account_info.stdout | from_json | json_query('user.name') }}"
+    plat__azure_subscription_id: "{{ __azure_account_info.stdout | from_json | community.general.json_query('id') }}"
+    plat__azure_subscription_name: "{{ __azure_account_info.stdout | from_json | community.general.json_query('name') }}"
+    plat__azure_tenant_id: "{{ __azure_account_info.stdout | from_json | community.general.json_query('tenantId') }}"
+    plat__azure_calling_user: "{{ __azure_account_info.stdout | from_json | community.general.json_query('user.name') }}"
 
 - name: Set Azure Subscription URI
   ansible.builtin.set_fact:
@@ -44,7 +44,7 @@
 - name: Set fact Azure App UUID, if exists
   when: __azure_xaccount_app.stdout != "[]"
   ansible.builtin.set_fact:
-    plat__azure_xaccount_app_uuid: "{{ __azure_xaccount_app.stdout | from_json | json_query('[0].appId') }}"
+    plat__azure_xaccount_app_uuid: "{{ __azure_xaccount_app.stdout | from_json | community.general.json_query('[0].appId') }}"
 
 - name: Get Azure Resource Group matching Namespace, if exists
   azure.azcollection.azure_rm_resourcegroup_info:
@@ -66,7 +66,7 @@
 
     - name: Set Service Principal Object UUID for Azure App
       ansible.builtin.set_fact:
-        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | json_query('[0].objectId') }}"
+        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
 
 - name: Get Azure Cross Account Role Info if exists
   azure.azcollection.azure_rm_roledefinition_info:
@@ -89,7 +89,7 @@
     - __azure_identity_list.stdout is defined
     - __azure_identity_list.stdout | count > 0
   ansible.builtin.set_fact:
-    __azure_identity_list_names: "{{ __azure_identity_list.stdout | from_json | json_query('[*].name') }}"
+    __azure_identity_list_names: "{{ __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') }}"
 
 - name: Fetch Azure Security Group Info
   register: __azure_sg_info
@@ -99,8 +99,8 @@
   when: __azure_sg_info | length > 0
   ignore_errors: True  # We do not want to fail if collecting facts and nsg are not already present
   ansible.builtin.set_fact:
-    __azure_sec_group_knox_uri: "{{ __azure_sg_info.stdout | from_json | json_query(__azure_jq_knox) | first }}"
-    __azure_sec_group_default_uri: "{{ __azure_sg_info.stdout | from_json | json_query(__azure_jq_default) | first }}"
+    __azure_sec_group_knox_uri: "{{ __azure_sg_info.stdout | from_json | community.general.json_query(__azure_jq_knox) | first }}"
+    __azure_sec_group_default_uri: "{{ __azure_sg_info.stdout | from_json | community.general.json_query(__azure_jq_default) | first }}"
   vars:
     __azure_jq_knox: "[?name=='{{ plat__security_group_knox_name }}'].id"
     __azure_jq_default: "[?name=='{{ plat__security_group_default_name }}'].id"
@@ -108,10 +108,10 @@
 - name: Extract Azure Identity Principals
   ignore_errors: True
   ansible.builtin.set_fact:
-    __azure_idbroker_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_idbroker_uri) | first }}"
-    __azure_datalakeadmin_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_dtadmin_uri) | first }}"
-    __azure_log_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_log_rl_uri) | first }}"
-    __azure_ranger_audit_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_rngr_rl_uri) | first }}"
+    __azure_idbroker_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_idbroker_uri) | first }}"
+    __azure_datalakeadmin_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_dtadmin_uri) | first }}"
+    __azure_log_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_log_rl_uri) | first }}"
+    __azure_ranger_audit_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_rngr_rl_uri) | first }}"
   vars:
     jq_idbroker_uri: "[?name=='{{ plat__azure_idbroker_identity_name }}'].id"
     jq_dtadmin_uri: "[?name=='{{ plat__azure_datalakeadmin_identity_name }}'].id"
@@ -131,7 +131,7 @@
 - name: Set Azure NetApp Volume Start IP if exists
   when: __azure_netapp_nfs_info.stdout != ''
   ansible.builtin.set_fact:
-    __azure_netapp_startip: "{{ __azure_netapp_nfs_info.stdout | from_json | json_query('mountTargets[0].ipAddress') }}"
+    __azure_netapp_startip: "{{ __azure_netapp_nfs_info.stdout | from_json | community.general.json_query('mountTargets[0].ipAddress') }}"
 
 - name: Set Azure NetApp Volume Info if exists
   when: __azure_netapp_startip is defined

--- a/roles/platform/tasks/initialize_teardown.yml
+++ b/roles/platform/tasks/initialize_teardown.yml
@@ -14,6 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Refresh Environment Info with Descendants
+  cloudera.cloud.env_info:
+    name: "{{ plat__env_name }}"
+    descendants: true
+  register: plat__env_info
+
+- name: Check that Environment has no descendants before Platform teardown
+  when: plat__env_info.environments | length > 0
+  ansible.builtin.assert:
+    that:
+      - plat__env_info.environments[0].descendants.datahub | length == 0
+      - plat__env_info.environments[0].descendants.df | length == 0
+      - plat__env_info.environments[0].descendants.dw | length == 0
+      - plat__env_info.environments[0].descendants.opdb | length == 0
+    fail_msg: "Environment {{ plat__env_name }} has one or more child services registered, please check and try again"
+    quiet: yes
+
 - name: Include provider-specific initialization base
   ansible.builtin.include_tasks: "initialize_{{ plat__infra_type | lower }}.yml"
 

--- a/roles/platform/tasks/initialize_teardown_azure.yml
+++ b/roles/platform/tasks/initialize_teardown_azure.yml
@@ -36,4 +36,4 @@
 
 - name: Set list of role assignment names to delete
   ansible.builtin.set_fact:
-    __plat_azure_role_assignment_names_list: "{{ __plat__azure_roles_discovered.results | json_query('[*].roleassignments') | select() | json_query('[*][0].id') }}"
+    __plat_azure_role_assignment_names_list: "{{ __plat__azure_roles_discovered.results | community.general.json_query('[*].roleassignments') | select() | community.general.json_query('[*][0].id') }}"

--- a/roles/platform/tasks/setup_azure_authz.yml
+++ b/roles/platform/tasks/setup_azure_authz.yml
@@ -40,8 +40,8 @@
     - name: Register Azure Cross Account App info
       no_log: True
       set_fact:
-        __azure_xaccount_app_pword: "{{ __azure_xaccount_app_info.stdout | from_json | json_query('password')  }}"
-        plat__azure_xaccount_app_uuid: "{{ __azure_xaccount_app_info.stdout | from_json | json_query('appId')  }}"
+        __azure_xaccount_app_pword: "{{ __azure_xaccount_app_info.stdout | from_json | community.general.json_query('password')  }}"
+        plat__azure_xaccount_app_uuid: "{{ __azure_xaccount_app_info.stdout | from_json | community.general.json_query('appId')  }}"
 
     - name: Get Service Principal for Azure App
       when: ( plat__azure_xaccount_app_uuid is defined ) and ( plat__azure_xaccount_app_uuid | length > 0 )
@@ -54,7 +54,7 @@
 
         - name: Set Service Principal Object UUID for Azure App
           ansible.builtin.set_fact:
-            plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | json_query('[0].objectId') }}"
+            plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
 
     - name: Create the CDP Cross Account Credential with the new Azure App details
       cloudera.cloud.env_cred:
@@ -73,10 +73,10 @@
     name: "{{ plat__azure_xaccount_role_name }}"
     assignable_scopes: "/subscriptions/{{ plat__azure_subscription_id }}"
     permissions:
-      - actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | json_query('Actions') }}"
-        data_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | json_query('DataActions') }}"
-        not_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | json_query('NotActions') }}"
-        not_data_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | json_query('NotDataActions') }}"
+      - actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | community.general.json_query('Actions') }}"
+        data_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | community.general.json_query('DataActions') }}"
+        not_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | community.general.json_query('NotActions') }}"
+        not_data_actions: "{{ lookup('file', __azure_policy_document.dest ) | from_json | community.general.json_query('NotDataActions') }}"
 
 - name: Set Azure Cross Account Role URI
   ansible.builtin.set_fact:
@@ -101,21 +101,21 @@
   delay: 5
   retries: 10
   until:
-    - plat__azure_idbroker_identity_name in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_datalakeadmin_identity_name in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_log_identity_name in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_ranger_audit_identity_name in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
+    - plat__azure_idbroker_identity_name in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_datalakeadmin_identity_name in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_log_identity_name in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_ranger_audit_identity_name in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
 
 - name: Extract Azure Identity Principals
   ansible.builtin.set_fact:
-    __azure_idbroker_identity_uuid: "{{ __azure_identity_list.stdout | from_json | json_query(jq_idbroker_uuid) | first }}"
-    __azure_idbroker_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_idbroker_uri) | first }}"
-    __azure_datalakeadmin_identity_uuid: "{{ __azure_identity_list.stdout | from_json | json_query(jq_dtadmin_uuid) | first }}"
-    __azure_datalakeadmin_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_dtadmin_uri) | first }}"
-    __azure_log_identity_uuid: "{{ __azure_identity_list.stdout | from_json | json_query(jq_log_rl_uuid) | first }}"
-    __azure_log_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_log_rl_uri) | first }}"
-    __azure_ranger_audit_identity_uuid: "{{ __azure_identity_list.stdout | from_json | json_query(jq_rngr_rl_uuid) | first }}"
-    __azure_ranger_audit_identity_uri: "{{ __azure_identity_list.stdout | from_json | json_query(jq_rngr_rl_uri) | first }}"
+    __azure_idbroker_identity_uuid: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_idbroker_uuid) | first }}"
+    __azure_idbroker_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_idbroker_uri) | first }}"
+    __azure_datalakeadmin_identity_uuid: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_dtadmin_uuid) | first }}"
+    __azure_datalakeadmin_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_dtadmin_uri) | first }}"
+    __azure_log_identity_uuid: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_log_rl_uuid) | first }}"
+    __azure_log_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_log_rl_uri) | first }}"
+    __azure_ranger_audit_identity_uuid: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_rngr_rl_uuid) | first }}"
+    __azure_ranger_audit_identity_uri: "{{ __azure_identity_list.stdout | from_json | community.general.json_query(jq_rngr_rl_uri) | first }}"
   vars:
     jq_idbroker_uuid: "[?name=='{{ plat__azure_idbroker_identity_name }}'].principalId"
     jq_idbroker_uri: "[?name=='{{ plat__azure_idbroker_identity_name }}'].id"
@@ -133,12 +133,12 @@
 
 - name: Extract Azure Role Definition URIs
   ansible.builtin.set_fact:
-    __azure_xaccount_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_xaccount_uri_jq) | first }}"
-    __azure_virtualmachine_ctrb_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_vmcnt_uri_jq) | first }}"
-    __azure_managedidentity_optr_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_miop_uri_jq) | first }}"
-    __azure_storageblobdata_ownr_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_storown_uri_jq) | first }}"
-    __azure_storageblobdata_ctrb_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_storcnt_uri_jq) | first }}"
-    __azure_contributor_role_uri: "{{ __azure_role_definition_info.roledefinitions | json_query(__azure_contrib_uri_jq) | first }}"
+    __azure_xaccount_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_xaccount_uri_jq) | first }}"
+    __azure_virtualmachine_ctrb_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_vmcnt_uri_jq) | first }}"
+    __azure_managedidentity_optr_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_miop_uri_jq) | first }}"
+    __azure_storageblobdata_ownr_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_storown_uri_jq) | first }}"
+    __azure_storageblobdata_ctrb_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_storcnt_uri_jq) | first }}"
+    __azure_contributor_role_uri: "{{ __azure_role_definition_info.roledefinitions | community.general.json_query(__azure_contrib_uri_jq) | first }}"
   vars:
     __azure_xaccount_uri_jq: "[?role_name=='{{ plat__azure_xaccount_role_name }}'].id"
     __azure_vmcnt_uri_jq: "[?role_name=='{{ plat__azure_roles.vmcnt }}'].id"

--- a/roles/platform/tasks/teardown_azure_authz.yml
+++ b/roles/platform/tasks/teardown_azure_authz.yml
@@ -46,7 +46,7 @@
   delay: 5
   retries: 10
   until:
-    - plat__azure_idbroker_identity_name not in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_datalakeadmin_identity_name not in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_log_identity_name not in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
-    - plat__azure_ranger_audit_identity_name not in ( __azure_identity_list.stdout | from_json | json_query('[*].name') )
+    - plat__azure_idbroker_identity_name not in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_datalakeadmin_identity_name not in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_log_identity_name not in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )
+    - plat__azure_ranger_audit_identity_name not in ( __azure_identity_list.stdout | from_json | community.general.json_query('[*].name') )

--- a/roles/runtime/defaults/main.yml
+++ b/roles/runtime/defaults/main.yml
@@ -34,12 +34,16 @@ run__public_endpoint_access:        "{{ common__public_endpoint_access }}"
 
 run__gcp_project:                   "{{ common__gcp_project }}"
 
+# Teardown
+run__force_teardown:                "{{ common__force_teardown }}"
+
 run__datahub_image_catalog_url:     "{{ datahub.image_catalog.url | default('https://cloudbreak-imagecatalog.s3.amazonaws.com/v3-prod-cb-image-catalog.json') }}"
 run__datahub_image_catalog_name:    "{{ datahub.image_catalog.name | default('cdp-default') }}"
 run__datahub_instance_group_base:   "{{ datahub.instance_group_base | default(lookup('template', 'datahub_instance_group_base.j2') | from_yaml) }}"
 run__datahub_suffix:                "{{ datahub.suffix | default('dhub') }}"
 run__datahub_tags:                  "{{ datahub.tags | default(common__tags) }}"
 run__datahub_definitions:           "{{ datahub.definitions | default([]) }}"
+run__datahub_force_teardown:        "{{ datahub.force_delete | default(run__force_teardown) }}"
 
 run__datahub_compute_aws:           "{{ datahub.compute.aws | default({}) }}"
 run__datahub_compute_azure:         "{{ datahub.compute.azure | default({}) }}"
@@ -56,16 +60,20 @@ run__ml_definitions:                "{{ ml.definitions | default([{}]) }}"
 run__ml_suffix:                     "{{ ml.suffix | default('wksp') }}"
 run__ml_k8s_request_base:           "{{ ml.k8s_request_base | default(lookup('template', 'ml_k8s_request_base.j2') | from_yaml) }}"
 run__ml_tags:                       "{{ ml.tags | default(common__tags) }}"
+run__ml_force_delete:               "{{ ml.force_delete | default (run__force_teardown) }}"
+run__ml_remove_storage:             "{{ ml.remove_storage | default (run__force_teardown) }}"
 run__ml_public_loadbalancer:        "{{ ml.public_loadbalancer | default(run__public_endpoint_access) }}"
 
 run__dw_definitions:                "{{ dw.definitions | default([{}]) }}"
 run__dw_suffix:                     "{{ dw.suffix | default('dw') }}"
+run__dw_force_delete:               "{{ dw.force_delete | default (run__force_teardown) }}"
 
 run__df_nodes_min:                  "{{ df.min_k8s_nodes | default(3) }}"
 run__df_nodes_max:                  "{{ df.max_k8s_nodes | default(5) }}"
 run__df_public_loadbalancer:        "{{ df.public_loadbalancer | default(run__public_endpoint_access) }}"
 run__df_ip_ranges:                  "{{ df.ip_ranges | default([]) }}"
 run__df_persist:                    "{{ df.teardown.persist | default(False) }}"
+run__df_force_delete:               "{{ df.force_delete | default (run__force_teardown) }}"
 
 # Deploy
 run__include_ml:                     "{{ common__include_ml }}"

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -21,8 +21,9 @@
   failed_when: __cdp_env_info.environments is not defined
 
 - name: Set fact for CDP Environment CRN
+  when: __cdp_env_info.environments | length > 0
   ansible.builtin.set_fact:
-    run__cdp_env_crn: "{{ __cdp_env_info.environments[0].crn | d('') }}"
+    run__cdp_env_crn: "{{ __cdp_env_info.environments[0].crn }}"
 
 - name: Discover CDP Datalake version
   when: plat__cdp_datalake_version is undefined

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -69,11 +69,6 @@
 - name: Prepare for CDP Datahub clusters
   when: run__include_datahub
   block:
-    - name: Retrieve CDP Datahub clusters
-      cloudera.cloud.datahub_cluster_info:
-        env: "{{ run__env_name }}"
-      register: run__datahub_list
-
     - name: Retrieve Image Catalog File
       ansible.builtin.uri:
         url: "{{ run__datahub_image_catalog_url }}"
@@ -137,11 +132,6 @@
 - name: Prepare for CDP OpDB experiences
   when: run__include_opdb
   block:
-    - name: Retrieve CDP OpDB experiences
-      cloudera.cloud.opdb_info:
-        env: "{{ run__env_name }}"
-      register: run__opdb_list
-
     - name: Construct OpDB Configurations
       ansible.builtin.set_fact:
         run__opdb_configs: "{{ run__opdb_configs | default([]) | union([config]) }}"
@@ -157,11 +147,6 @@
 - name: Prepare for CDP ML Workspace experiences
   when: run__include_ml
   block:
-    - name: Retrieve CDP ML Workspace experiences
-      cloudera.cloud.ml_info:
-        env: "{{ run__env_name }}"
-      register: run__ml_list
-
     - name: Construct CDP ML Workspace configurations
       ansible.builtin.set_fact:
         run__ml_configs: "{{ run__ml_configs | default([]) | union([config]) }}"
@@ -184,11 +169,3 @@
       loop_control:
         loop_var: __ml_config
         label: "{{ config.name }}"
-
-- name: Prepare for CDP DW experiences
-  when: run__include_dw
-  block:
-    - name: Retrieve CDP DW experiences
-      cloudera.cloud.dw_cluster_info:
-        env: "{{ run__env_name }}"
-      register: run__dw_list

--- a/roles/runtime/tasks/initialize_setup_gcp.yml
+++ b/roles/runtime/tasks/initialize_setup_gcp.yml
@@ -48,4 +48,4 @@
     - __gcp_subnets_discovered.resources | length > 0
     #- __gcp_subnet_item.selfLink in run__gcp_vpc_discovered.subnetworks
   ansible.builtin.set_fact:
-    run__datahub_subnet_ids: "{{ __gcp_subnets_discovered | json_query('resources[*].name') }}"
+    run__datahub_subnet_ids: "{{ __gcp_subnets_discovered | community.general.json_query('resources[*].name') }}"

--- a/roles/runtime/tasks/initialize_teardown.yml
+++ b/roles/runtime/tasks/initialize_teardown.yml
@@ -14,5 +14,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Refresh Environment Info with Descendants
+  cloudera.cloud.env_info:
+    name: "{{ run__env_name }}"
+    descendants: true
+  register: run__env_info
+
 - name: Initialize Runtime teardown
+  when: not run__force_teardown
   ansible.builtin.include_tasks: "initialize_base.yml"
+
+- name: Initialize Purge of all Runtimes in Environment
+  when:
+    - run__force_teardown | bool
+    - run__env_info.environments | length > 0
+  block:
+    - name: Prepare teardown list of all Datahubs in Environment
+      ansible.builtin.set_fact:
+        run__datahub_configs: "{{ run__datahub_configs | default([]) | union([config]) }}"
+      vars:
+        config:
+          name: "{{ __datahub_config.clusterName }}"
+      loop: "{{ run__env_info.environments[0].descendants.datahub }}"
+      loop_control:
+        loop_var: __datahub_config
+        label: "{{ __datahub_config.clusterName }}"
+
+    - name: Prepare teardown list of all OpDB Experiences in Environment
+      ansible.builtin.set_fact:
+        run__opdb_configs: "{{ run__opdb_configs | default([]) | union([config]) }}"
+      vars:
+        config:
+          name: "{{ __opdb_config.databaseName }}"
+          env: "{{ __opdb_config.environmentName }}"
+      loop: "{{ run__env_info.environments[0].descendants.opdb }}"
+      loop_control:
+        loop_var: __opdb_config
+        label: "{{ __opdb_config.databaseName }}"
+
+    - name: Prepare teardown list of all ML Experiences in Environment
+      ansible.builtin.set_fact:
+        run__ml_configs: "{{ run__ml_configs | default([]) | union([config]) }}"
+      vars:
+        config:
+          name: "{{ __ml_config.instanceName }}"
+          env: "{{ __ml_config.environmentName }}"
+      loop: "{{ run__env_info.environments[0].descendants.ml }}"
+      loop_control:
+        loop_var: __ml_config
+        label: "{{ __ml_config.instanceName }}"

--- a/roles/runtime/tasks/initialize_teardown.yml
+++ b/roles/runtime/tasks/initialize_teardown.yml
@@ -24,6 +24,12 @@
   when: not run__force_teardown
   ansible.builtin.include_tasks: "initialize_base.yml"
 
+- name: Discover CDP DF Deployments
+  register: run__df_env_info
+  when: run__include_df
+  cloudera.cloud.df_info:
+    name: "{{ run__env_name }}"
+
 - name: Initialize Purge of all Runtimes in Environment
   when:
     - run__force_teardown | bool

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -48,13 +48,16 @@
   register: __df_teardown_info
   when:
     - run__include_df
-    - run__env_info.environments | length > 0
-    - run__env_info.environments[0].descendants.df | length > 0
+    - run__df_env_info.services | length > 0
   cloudera.cloud.df:
-    name: "{{ run__cdp_env_crn }}"
+    name: "{{ __df_teardown_req_item.crn }}"
     persist: "{{ run__df_persist }}"
+    force: "{{ run__df_force_delete }}"
     state: absent
     wait: no
+  loop_control:
+    loop_var: __df_teardown_req_item
+  loop: "{{ run__df_env_info.services }}"
 
 - name: Execute CDP ML Workspace teardown
   when:
@@ -128,8 +131,7 @@
 - name: Wait for CDP DW deployments to decommission
   when:
     - __dw_teardown_info is defined
-    - __dw_teardown_info.results is defined
-    - __dw_teardown_info.results | length > 0
+    - __dw_teardown_info.started | default(False)
   cloudera.cloud.dw_cluster:
     env: "{{ run__env_name }}"
     state: absent
@@ -154,11 +156,14 @@
 
 - name: Wait for CDP Dataflow deployment to decommission
   when:
-    - __df_teardown_info is defined
-    - __df_teardown_info.results is defined
-    - __df_teardown_info.started | default(False)
+    - run__include_df
+    - run__df_env_info.services | length > 0
   cloudera.cloud.df:
-    name: "{{ run__cdp_env_crn }}"
+    name: "{{ __df_teardown_wait_item.crn }}"
     persist: "{{ run__df_persist }}"
+    force: "{{ run__df_force_delete }}"
     state: absent
     wait: yes
+  loop_control:
+    loop_var: __df_teardown_wait_item
+  loop: "{{ run__df_env_info.services }}"

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -14,22 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Execute CDP Datahub teardown
-  when: run__include_datahub
-  cloudera.cloud.datahub_cluster:
-    name: "{{ __datahub_config_item.name }}"
-    state: absent
-    wait: yes
-  loop_control:
-    loop_var: __datahub_config_item
-    label: "{{ __datahub_config_item.name | default('datahub') }}"
-  loop: "{{ run__datahub_configs }}"
-  async: 3600 # 1 hour timeout
-  poll: 0
-  register: __datahub_teardowns_info
-
 - name: Execute CDP OpDB teardown
-  when: run__include_opdb
+  when:
+    - run__include_opdb
+    - run__opdb_configs is defined
+    - run__opdb_configs | length > 0
   cloudera.cloud.opdb:
     env: "{{ run__env_name }}"
     name: "{{ __opdb_config.name }}"
@@ -44,17 +33,23 @@
   register: __opdb_teardowns_info
 
 - name: Execute CDP DW cluster teardown
-  when: run__include_dw
+  register: __dw_teardown_info
+  when:
+    - run__include_dw
+    - run__env_info.environments | length > 0
+    - run__env_info.environments[0].descendants.dw | length > 0
   cloudera.cloud.dw_cluster:
     env: "{{ run__env_name }}"
     state: absent
-    wait: yes
-  async: 3600 # 1 hour timeout
-  poll: 0
-  register: __dw_teardowns_info
+    wait: no
+    force: "{{ run__dw_force_delete }}"
 
 - name: Execute CDP Dataflow teardown
-  when: run__include_df
+  register: __df_teardown_info
+  when:
+    - run__include_df
+    - run__env_info.environments | length > 0
+    - run__env_info.environments[0].descendants.df | length > 0
   cloudera.cloud.df:
     name: "{{ run__cdp_env_crn }}"
     persist: "{{ run__df_persist }}"
@@ -62,11 +57,16 @@
     wait: no
 
 - name: Execute CDP ML Workspace teardown
-  when: run__include_ml
+  when:
+    - run__include_ml
+    - run__ml_configs is defined
+    - run__ml_configs | length > 0
   cloudera.cloud.ml:
     name: "{{ __ml_config_item.name }}"
     env: "{{ run__env_name }}"
     state: absent
+    remove_storage: "{{ run__ml_remove_storage }}"
+    force_delete: "{{ run__ml_force_delete }}"
   loop_control:
     loop_var: __ml_config_item
     label: "{{ __ml_config_item.name | default('ml') }}"
@@ -75,8 +75,29 @@
   poll: 0
   register: __ml_teardowns_info
 
+- name: Execute CDP Datahub teardown
+  when:
+    - run__include_datahub
+    - run__datahub_configs is defined
+    - run__datahub_configs | length > 0
+  cloudera.cloud.datahub_cluster:
+    name: "{{ __datahub_config_item.name }}"
+    state: absent
+    force: "{{ run__datahub_force_teardown }}"
+    wait: yes
+  loop_control:
+    loop_var: __datahub_config_item
+    label: "{{ __datahub_config_item.name | default('datahub') }}"
+  loop: "{{ run__datahub_configs }}"
+  async: 3600 # 1 hour timeout
+  poll: 0
+  register: __datahub_teardowns_info
+
 - name: Wait for CDP ML Workspace deployments to decommission
-  when: run__include_ml
+  when:
+    - __ml_teardowns_info is defined
+    - __ml_teardowns_info.results is defined
+    - __ml_teardowns_info.results | length > 0
   ansible.builtin.async_status:
     jid: "{{ __ml_teardown.ansible_job_id }}"
   loop_control:
@@ -89,7 +110,10 @@
   delay: 30
 
 - name: Wait for CDP Datahub deployments to decommission
-  when: run__include_datahub
+  when:
+    - __datahub_teardowns_info is defined
+    - __datahub_teardowns_info.results is defined
+    - __datahub_teardowns_info.results | length > 0
   ansible.builtin.async_status:
     jid: "{{ __datahub_teardown_item.ansible_job_id }}"
   loop_control:
@@ -102,20 +126,21 @@
   delay: 30
 
 - name: Wait for CDP DW deployments to decommission
-  when: run__include_dw
-  ansible.builtin.async_status:
-    jid: "{{ __dw_teardown.ansible_job_id }}"
-  loop_control:
-    loop_var: __dw_teardown
-    label: "{{ __dw_teardown.__dw_config.name | default('dw') }}"
-  loop: "{{ __dw_teardowns_info.results }}"
-  register: __dw_teardowns_async
-  until: __dw_teardowns_async.finished
-  retries: 120
-  delay: 30
+  when:
+    - __dw_teardown_info is defined
+    - __dw_teardown_info.results is defined
+    - __dw_teardown_info.results | length > 0
+  cloudera.cloud.dw_cluster:
+    env: "{{ run__env_name }}"
+    state: absent
+    wait: yes
+    force: "{{ run__dw_force_delete }}"
 
 - name: Wait for CDP OpDB deployments to decommission
-  when: run__include_opdb
+  when:
+    - __opdb_teardowns_info is defined
+    - __opdb_teardowns_info.results is defined
+    - __opdb_teardowns_info.results | length > 0
   ansible.builtin.async_status:
     jid: "{{ __opdb_teardown.ansible_job_id }}"
   loop_control:
@@ -128,7 +153,10 @@
   delay: 30
 
 - name: Wait for CDP Dataflow deployment to decommission
-  when: run__include_df
+  when:
+    - __df_teardown_info is defined
+    - __df_teardown_info.results is defined
+    - __df_teardown_info.started | default(False)
   cloudera.cloud.df:
     name: "{{ run__cdp_env_crn }}"
     persist: "{{ run__df_persist }}"


### PR DESCRIPTION
Dependent on:
https://github.com/cloudera-labs/cloudera.cloud/pull/18
https://github.com/cloudera-labs/cdpy/pull/22
https://github.com/cloudera-labs/cloudera.cloud/pull/17  # Expects DF to be present in services

Introduce 'purge' keyword for Definitions to signal that an AWS VPC and all child objects, and all unattached EBS volumes in the name_prefix, should be removed from the given infra_region
Add network, compute, and storage discovery to AWS Initialization
Add teardown of discovered network, compute and storage when purge is used
Enforce check that a CDP Environment has no listed descendants before allowing teardown
Add new Runtime purge discovery and execution controlled by new purge key
Move Datahub purge to after Experiences that lean on Datahubs for execution to allow controlled removal to be tried first
Improve async wait for Runtime removal to complete
Add force delete, and force data removal options to Runtimes where appropriate

Standardise usage of json_query to correctly use FQCN of community.general.json_query
Add warning to Create AWS Buckets function for common error where user attempts to create a bucket that is already owned elsewhere
Remove unused Runtime service info registrations

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>