### PR TITLE
Add Centos8 to Dynamic Inventory options

### DIFF
--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -70,7 +70,7 @@
         region: "{{ infra__region }}"
         filters:
           name: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os].search }}"
-          owner-alias: aws-marketplace
+        owners: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os].owners }}"
       register: __infra_aws_ami_list
 
     - name:  Filter to latest Image

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -31,6 +31,13 @@ infra__dynamic_inventory_images_default:
     centos7:
       search: 'CentOS Linux 7 x86_64 HVM EBS*'
       user: 'centos'
+      owners:
+        - 'aws-marketplace'
+    centos8:
+      search: 'CentOS 8.2*x86*'
+      user: 'centos'
+      owners:
+        - '125523088429'
 
 infra__all_ports_security_rule:
   aws: -1


### PR DESCRIPTION
Improve AMI owners selection to be configurable
Add defaults for aws-marketplace option for centos8 AMI

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>