### PR TITLE
Improve network security port determination logic

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -125,7 +125,13 @@ common__tunnel:                           "{{ env.tunnel | default(False) }}"
 common__public_endpoint_access:           "{{ env.public_endpoint_access | default(not common__tunnel) }}"
 
 common__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
+
 # Deploy
+common__setup_runtime:                    "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) | bool }}"
+common__setup_plat:                       "{{ env is defined or sequence__setup_runtime  | default(False) | bool }}"
+common__setup_infra:                      "{{ infra is defined or sequence__setup_plat | default(False) | bool }}"
+common__setup_base:                       "{{ mgmt is defined or clusters is defined | default(False) | bool }}"
+
 common__include_ml:                        "{{ ml is defined | bool }}"
 common__include_dw:                        "{{ dw is defined | bool }}"
 common__include_de:                        "{{ de is defined | bool }}"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -72,7 +72,11 @@ infra__vpc_svcnet_name:             "{{ infra.vpc.service_network.name | default
 infra__vpc_public_subnet_cidrs:     "{{ common__vpc_public_subnet_cidrs }}"
 infra__vpc_private_subnet_cidrs:    "{{ common__vpc_private_subnet_cidrs }}"
 
-infra__vpc_extra_ports:             "{{ infra.vpc.extra_ports | default([22, 443, 7180, 7183]) }}"
+infra__allow_ssh_access:            "{{ infra.vpc.enable_ssh | default(True) }}"
+infra__vpc_cloud_ports:             "{{ infra.vpc.cloud_ports | default([443]) }}"
+infra__vpc_base_ports:              "{{ infra.vpc.base_ports | default([7180, 7183]) }}"
+infra__vpc_ssh_ports:               "{{ infra.vpc.ssh_ports | default([22]) }}"
+infra__vpc_extra_ports:             "{{ infra.vpc.extra_ports | default(common__setup_base | ternary(infra__vpc_base_ports, []) | union( common__setup_plat | ternary(infra__vpc_cloud_ports, [])) | union(infra__allow_ssh_access | ternary(infra__vpc_ssh_ports, [])) ) }}"
 infra__vpc_extra_cidr:              "{{ infra.vpc.extra_cidr | default([]) }}"
 infra__vpc_user_ports:              "{{ infra.vpc.user_ports | default([infra__all_ports_security_rule[infra__type]]) }}"
 infra__vpc_user_cidr:               "{{ infra.vpc.user_cidr | default([]) }}"

--- a/roles/sequence/defaults/main.yml
+++ b/roles/sequence/defaults/main.yml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-sequence__setup_runtime:  "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) | bool }}"
+sequence__setup_runtime:  "{{ common__setup_runtime }}"
 
-sequence__setup_plat:     "{{ env is defined or sequence__setup_runtime  | default(False) | bool }}"
+sequence__setup_plat:     "{{ common__setup_plat }}"
 
-sequence__setup_infra:    "{{ infra is defined or sequence__setup_plat | default(False) | bool }}"
+sequence__setup_infra:    "{{ common__setup_infra }}"
 
 sequence_init:            "{{ sequence__setup_infra }}"


### PR DESCRIPTION
Move top level key derivation to common role from sequence role
Add derivation key 'common__setup_base' for cdp private base
Split default extra network ports into ssh, cloud, and base port groups, with appropriate dot notation keys under infra.vpc
add switch 'infra.vpc.enable_ssh', defaulted to True, to allow port 22/ssh access
switch including cm ports 7180/7183 by default when 'mgmt' or 'clusters' is defined for base deployment
switch including https/443 on when cdp public platform is deployed. It may also be included by overriding the defaults.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>