### PR TITLE
Correct references to AWS policy documents

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -124,7 +124,8 @@ common__datalake_name_suffix:             "{{ env.datalake.suffix | default(comm
 common__tunnel:                           "{{ env.tunnel | default(False) }}"
 common__public_endpoint_access:           "{{ env.public_endpoint_access | default(not common__tunnel) }}"
 
-common__env_admin_password:                     "{{ globals.admin_password | mandatory }}"
+common__env_admin_password:               "{{ globals.admin_password | mandatory }}"
+common__aws_policy_urls_default_root:     "https://raw.githubusercontent.com/hortonworks/cloudbreak/master/cloud-aws-common/src/main/resources/definitions/cdp"
 
 # Deploy
 common__setup_runtime:                    "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) | bool }}"

--- a/roles/data/vars/main.yml
+++ b/roles/data/vars/main.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data__aws_policy_urls_default_root:   "https://github.com/hortonworks/cloudbreak/raw/master/cloud-aws/src/main/resources/definitions/cdp"
+data__aws_policy_urls_default_root:   "{{ common__aws_policy_urls_default_root }}"
 data__aws_policy_urls_default:
   read_only:                          "{{ data__aws_policy_urls_default_root }}/aws-cdp-bucket-access-policy.json"
   read_write:                         "{{ data__aws_policy_urls_default_root }}/aws-cdp-datalake-admin-s3-policy.json"  

--- a/roles/platform/vars/main.yml
+++ b/roles/platform/vars/main.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 # Vars for platform
-plat__aws_policy_urls_default_root: "https://raw.githubusercontent.com/hortonworks/cloudbreak/master/cloud-aws-common/src/main/resources/definitions/cdp"
+plat__aws_policy_urls_default_root: "{{ common__aws_policy_urls_default_root }}"
 plat__aws_policy_urls_default:
   log:                "{{ plat__aws_policy_urls_default_root }}/aws-cdp-log-policy.json"
   ranger_audit_s3:    "{{ plat__aws_policy_urls_default_root }}/aws-cdp-ranger-audit-s3-policy.json"


### PR DESCRIPTION
Fix Issue #26
Move path to aws policy documents to common role
promulgate to plat and data roles

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>