### PR TITLE
Improve Azure deployment stability

### DIFF
--- a/roles/infrastructure/tasks/setup_azure_storage.yml
+++ b/roles/infrastructure/tasks/setup_azure_storage.yml
@@ -15,6 +15,8 @@
 # limitations under the License.
 
 - name: Request Azure Storage Account Creation with HNS
+  register: __infra_az_stor_acccount_test
+  ignore_errors: yes
   azure.azcollection.azure_rm_resource:
     state: present
     resource_group: "{{ infra__azure_metagroup_name }}"
@@ -31,6 +33,23 @@
         isHnsEnabled: yes
       location:  "{{ infra__region }}"
       tags: "{{ infra__tags }}"
+
+- name: Check Storage Account creation result for failure
+  when:
+    - __infra_az_stor_acccount_test.rc is defined
+    - __infra_az_stor_acccount_test.rc == 1
+  block:
+    - name: Test Azure Storage Account creation for StorageAccountAlreadyTaken
+      ansible.builtin.assert:
+        quiet: yes
+        that: '"StorageAccountAlreadyTaken" not in __infra_az_stor_acccount_test.module_stderr'
+        fail_msg: "Your proposed Storage Account Name {{ infra__azure_storage_name }} is already taken, please use another"
+
+    - name: Fail on any other Azure Storage Account Creation Error
+      ansible.builtin.assert:
+        quiet: yes
+        that: '"StorageAccountAlreadyTaken" in __infra_az_stor_acccount_test.module_stderr'
+        fail_msg: "Failed to Create Azure Storage Account with unanticipated error: {{ __infra_az_stor_acccount_test }}"
 
 - name: Wait for Azure Storage Account Creation
   register: __azure_storage_account_info
@@ -56,7 +75,7 @@
 - name: Handle Azure NetApp Storage if deploying CML
   when:
     - infra__ml_deploy
-    - __azure_netapp_vol_info is undefined or __azure_netapp_vol_info == ''
+    - infra__azure_nfs_mount is undefined or infra__azure_nfs_mount == ''
   block:
     - name: Handle Netapp Storage Account
       netapp.azure.azure_rm_netapp_account:
@@ -76,7 +95,7 @@
         service_level: "{{ infra__azure_netapp_pool_type }}"
 
     - name: Handle Azure NetApp Volume
-      register: __azure_netapp_vol_info
+      register: __azure_netapp_vol_details
       netapp.azure.azure_rm_netapp_volume:
         resource_group: "{{ infra__azure_metagroup_name }}"
         account_name: "{{ infra__azure_netapp_account_name }}"
@@ -90,6 +109,13 @@
         service_level: "{{ infra__azure_netapp_vol_type }}"
         size: "{{ infra__azure_netapp_vol_size }}"
 
-    - name: Prepare netapp vol info for submission
+    - name: Prepare netapp vol info for submission during initial creation
+      when: __azure_netapp_vol_details.msg is defined
       set_fact:
-        __azure_netapp_vol_info: "{{ __azure_netapp_vol_info.msg }}"
+        infra__azure_nfs_mount: "{{ __azure_netapp_vol_details.msg }}"
+
+    # Yay for Azure consistency
+    - name: Prepare netapp vol info for submission during recreation
+      when: __azure_netapp_vol_details.mount_path is defined
+      set_fact:
+        infra__azure_nfs_mount: "{{ __azure_netapp_vol_details.mount_path }}"

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -164,9 +164,10 @@ plat__azure_assignment_name_suffix:           "{{ env.azure.role.name_suffix.ass
 plat__azure_metagroup_name:                   "{{ common__azure_metagroup_name }}"
 plat__azure_storage_name:                     "{{ common__azure_storage_name }}"
 
+plat__azure_consistency_wait:                 "{{ env.azure.app.wait | default(10) }}"
 plat__azure_xaccount_app_name:                "{{ env.azure.app.name | default([plat__namespace, plat__azure_xaccount_suffix, plat__azure_app_suffix] | join('-')) }}"
 plat__azure_xaccount_role_name:               "{{ env.azure.role.name.cross_account | default([plat__namespace, plat__azure_xaccount_suffix, plat__azure_role_suffix] | join('-')) }}"
-plat__azure_policy_url:                       "{{ env.azure.policy.url | default('https://gist.github.com/gergopapi2/7b82e777624541ebf05114c57ad386cb/raw/bc9dd3927be0f205547f33ca15d00d2b71f72664/Cloudbreak%2520minimal%2520permissions,%2520azure,%2520for%2520multiple%2520RGs.%2520All%2520globs%2520resolved.') }}"
+plat__azure_policy_url:                       "{{ env.azure.policy.url | default('https://raw.githubusercontent.com/cloudera-labs/snippets/main/policies/azure/cloudbreak_minimal_multiple_rgs_v1.json') }}"
 
 plat__azure_log_identity_name:                "{{ env.azure.role.name.log | default([plat__namespace, plat__azure_log_suffix, plat__azure_identity_suffix] | join('-')) }}"
 plat__azure_datalakeadmin_identity_name:      "{{ env.azure.role.name.datalake_admin | default([plat__namespace, plat__azure_datalake_admin_suffix, plat__azure_identity_suffix] | join('-')) }}"

--- a/roles/platform/tasks/initialize_azure.yml
+++ b/roles/platform/tasks/initialize_azure.yml
@@ -81,10 +81,6 @@
         that: plat__azure_application_service_principal_objuuid | length > 0
         fail_msg: "Azure Service Principal Object ID appears to be length 0, please check and try again"
 
-- name: Print current plat__azure_application_service_principal_objuuid
-  debug:
-    msg: "{{ plat__azure_application_service_principal_objuuid | d('not set') }}"
-
 - name: Get Azure Cross Account Role Info if exists
   azure.azcollection.azure_rm_roledefinition_info:
     scope: "{{ plat__azure_subscription_uri }}"

--- a/roles/platform/tasks/initialize_azure.yml
+++ b/roles/platform/tasks/initialize_azure.yml
@@ -37,8 +37,8 @@
       "Calling User Name [{{ plat__azure_calling_user }}]"
     verbosity: 1
 
-- name: Refresh listing of Azure Apps matching Namespace
-  ansible.builtin.command: "az ad app list --display-name {{ plat__azure_xaccount_app_name }}"
+- name: Refresh listing of Azure Apps matching expected name {{ plat__azure_xaccount_app_name }}
+  ansible.builtin.command: "az ad app list --filter \"displayname eq '{{ plat__azure_xaccount_app_name }}'\""
   register: __azure_xaccount_app
 
 - name: Set fact Azure App UUID, if exists
@@ -64,9 +64,26 @@
         __azure_ad_filter: "appId eq '{{ plat__azure_xaccount_app_uuid }}'"
       register: __azure_application_service_principals_list
 
+    - name: Check that we found a valid Service Principal for the Azure App
+      ansible.builtin.assert:
+        quiet: yes
+        that: __azure_application_service_principals_list.stdout | from_json | length == 1
+        fail_msg: "Expected exactly one result from Azure Service Principal query for UUID {{ plat__azure_xaccount_app_uuid}}, got {{ __azure_application_service_principals_list.stdout | from_json | length }} instead"
+        success_msg: "Found New Azure Cross Account App in directory matching UUID {{ plat__azure_xaccount_app_uuid }}, using for Cross Account Credential Creation"
+
     - name: Set Service Principal Object UUID for Azure App
       ansible.builtin.set_fact:
         plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
+
+    - name: Check that Azure Service Principal ID is now set
+      ansible.builtin.assert:
+        quiet: yes
+        that: plat__azure_application_service_principal_objuuid | length > 0
+        fail_msg: "Azure Service Principal Object ID appears to be length 0, please check and try again"
+
+- name: Print current plat__azure_application_service_principal_objuuid
+  debug:
+    msg: "{{ plat__azure_application_service_principal_objuuid | d('not set') }}"
 
 - name: Get Azure Cross Account Role Info if exists
   azure.azcollection.azure_rm_roledefinition_info:
@@ -136,7 +153,7 @@
 - name: Set Azure NetApp Volume Info if exists
   when: __azure_netapp_startip is defined
   ansible.builtin.set_fact:
-    __azure_netapp_vol_info: "{{ __azure_netapp_startip }}:/{{ plat__azure_namespace }}"
+    infra__azure_nfs_mount: "{{ __azure_netapp_startip }}:/{{ plat__namespace }}"
 
 - name: Generate Public Subnet details
   ansible.builtin.set_fact:

--- a/roles/platform/tasks/setup_azure_authz.yml
+++ b/roles/platform/tasks/setup_azure_authz.yml
@@ -25,36 +25,66 @@
 
     - name: Remove Azure App as CDP Credential needs (re)creating
       when: plat__azure_xaccount_app_uuid is defined
-      command: "az ad app delete --id {{ plat__azure_xaccount_app_uuid }}"
+      block:
+        - name: Issue Azure App Delete command
+          command: "az ad app delete --id {{ plat__azure_xaccount_app_uuid }}"
 
-    # Owner role is required for DWX
+        - name: Wait for consistency
+          ansible.builtin.pause:
+            seconds: "{{ plat__azure_consistency_wait }}"
+
+    # Owner role is required for DWX if you are thinking of modifying this task
     - name: Request Azure Cross Account App Creation
       no_log: True
       register: __azure_xaccount_app_info
       command: >
         az ad sp create-for-rbac
-        --name http://{{ plat__azure_xaccount_app_name }}
+        --name {{ plat__azure_xaccount_app_name }}
         --role {{ plat__azure_roles.owner }}
         --scopes {{ plat__azure_metagroup_uri }}
 
     - name: Register Azure Cross Account App info
       no_log: True
-      set_fact:
+      ansible.builtin.set_fact:
         __azure_xaccount_app_pword: "{{ __azure_xaccount_app_info.stdout | from_json | community.general.json_query('password')  }}"
         plat__azure_xaccount_app_uuid: "{{ __azure_xaccount_app_info.stdout | from_json | community.general.json_query('appId')  }}"
 
-    - name: Get Service Principal for Azure App
-      when: ( plat__azure_xaccount_app_uuid is defined ) and ( plat__azure_xaccount_app_uuid | length > 0 )
-      block:
-        - name: Refresh listing of Azure Service Principals
-          ansible.builtin.command: "az ad sp list --filter {{ __azure_ad_filter | quote }}"
-          vars:
-            __azure_ad_filter: "appId eq '{{ plat__azure_xaccount_app_uuid }}'"
-          register: __azure_application_service_principals_list
+    - name: Validate that the Azure Cross Account App info has been set
+      no_log: True
+      ansible.builtin.assert:
+        quiet: yes
+        that:
+          - __azure_xaccount_app_pword | length > 0
+          - plat__azure_xaccount_app_uuid | length > 0
+        fail_msg: "Did not retrieve Cross Account App UUID and Password from creation, please try again"
+        success_msg: "Azure Cross Account App UUID and Password appear to have been extracted"
 
-        - name: Set Service Principal Object UUID for Azure App
-          ansible.builtin.set_fact:
-            plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
+    - name: Wait for consistency
+      ansible.builtin.pause:
+        seconds: "{{ plat__azure_consistency_wait }}"
+
+    - name: Refresh listing of Azure Service Principals
+      ansible.builtin.command: "az ad sp list --filter {{ __azure_ad_filter | quote }}"
+      vars:
+        __azure_ad_filter: "appId eq '{{ plat__azure_xaccount_app_uuid }}'"
+      register: __azure_application_service_principals_list
+
+    - name: Check that we found a valid Service Principal for the Azure App
+      ansible.builtin.assert:
+        quiet: yes
+        that: __azure_application_service_principals_list.stdout | from_json | length == 1
+        fail_msg: "Expected exactly one result from Azure Service Principal query for UUID {{ plat__azure_xaccount_app_uuid}}, got {{ __azure_application_service_principals_list.stdout | from_json | length }} instead"
+        success_msg: "Found New Azure Cross Account App in directory matching UUID {{ plat__azure_xaccount_app_uuid }}, using for Cross Account Credential Creation"
+
+    - name: Set Service Principal Object ID for new Azure App
+      ansible.builtin.set_fact:
+        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
+
+    - name: Check that Azure Service Principal ID is now set
+      ansible.builtin.assert:
+        quiet: yes
+        that: plat__azure_application_service_principal_objuuid | length > 0
+        fail_msg: "Azure Service Principal Object ID appears to be length 0, please check and try again"
 
     - name: Create the CDP Cross Account Credential with the new Azure App details
       cloudera.cloud.env_cred:
@@ -128,6 +158,7 @@
     
 - name: Refresh listing of Azure Role Definitions
   register: __azure_role_definition_info
+  no_log: yes   # Extremely verbose output
   azure.azcollection.azure_rm_roledefinition_info:
     scope: "{{ plat__azure_subscription_uri }}"
 
@@ -147,8 +178,27 @@
     __azure_storcnt_uri_jq: "[?role_name=='{{ plat__azure_roles.storcnt }}'].id"
     __azure_contrib_uri_jq: "[?role_name=='{{ plat__azure_roles.contrib }}'].id"
 
+- name: Wait for all Managed Identities to be available
+  command: "az ad sp show --id {{ __infra_az_sp_test_item }}"
+  register: __infra_az_sp_test_result
+  until: __infra_az_sp_test_result.rc == 0
+  retries: 5
+  delay: 5
+  loop_control:
+    loop_var: __infra_az_sp_test_item
+  loop:
+    - "{{ __azure_idbroker_identity_uuid }}"
+    - "{{ __azure_datalakeadmin_identity_uuid }}"
+    - "{{ __azure_log_identity_uuid  }}"
+    - "{{ __azure_ranger_audit_identity_uuid }}"
+    - "{{ plat__azure_application_service_principal_objuuid }}"
+
 - name: Process Azure Role Assignments
-  azure.azcollection.azure_rm_roleassignment: # This Azure module is not idempotent on removals
+  register: __infra_az_sp_assign_result
+  until: __infra_az_sp_assign_result is not failed
+  retries: 3
+  delay: 3
+  azure.azcollection.azure_rm_roleassignment: # This Azure module is not idempotent at all it seems?
     state: present
     scope: "{{ __azure_rl_assgn_item.scope }}"
     name: "{{ __azure_rl_assgn_item.name }}"
@@ -197,3 +247,4 @@
       desc: Assign Cross Account Role to Cross Account App
   loop_control:
     loop_var: __azure_rl_assgn_item
+    label: "{{ __azure_rl_assgn_item.desc }}"

--- a/roles/platform/tasks/setup_azure_env.yml
+++ b/roles/platform/tasks/setup_azure_env.yml
@@ -28,7 +28,8 @@
     public_key_text: "{{ plat__public_key_text }}"
     workload_analytics: "{{ plat__workload_analytics }}"
     vpc_id: "{{ plat__vpc_name }}"
+    tunnel: "{{ plat__tunnel }}"
     resource_gp: "{{ plat__azure_metagroup_name }}"
     subnet_ids: "{{ plat__azure_subnets }}"
-    public_ip: yes
+    public_ip: "{{ plat__public_endpoint_access }}"
     tags: "{{ plat__tags }}"

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -148,7 +148,8 @@
         overlay_network: "{{ __ml_config.network | default(include.network) | default({}) }}"
         base_instance_group: "{{ run__ml_k8s_request_base }}"
         config:
-          name: "{{ __ml_config.name | default([run__namespace, __ml_config.suffix | default(include.suffix) | default(run__ml_suffix)] | join('-')) }}"
+          name: "{{ __ml_config.name | default([run__namespace_cdp, __ml_config.suffix | default(include.suffix) | default(run__ml_suffix)] | join('-')) }}"
+          nfs: "{{ __ml_config.nfs | default(run__azure_nfs_mount | default(omit)) }}"
           k8s_request:
             environmentName: "{{ run__env_name }}"
             instanceGroups: "{{ overlay_instance_groups | map('cloudera.exe.combine_onto', base_instance_group, recursive=True) | list }}"

--- a/roles/runtime/tasks/initialize_setup.yml
+++ b/roles/runtime/tasks/initialize_setup.yml
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Initialize CDP Runtime setup
-  ansible.builtin.include_tasks: "initialize_base.yml"
-
 - name: Include provider-specific tasks to initialize Runtime setup
   ansible.builtin.include_tasks: "initialize_setup_{{ run__infra_type }}.yml"
+
+- name: Initialize CDP Runtime setup
+  ansible.builtin.include_tasks: "initialize_base.yml"

--- a/roles/runtime/tasks/initialize_setup_azure.yml
+++ b/roles/runtime/tasks/initialize_setup_azure.yml
@@ -16,3 +16,8 @@
   when: infra__azure_subnets is defined
   ansible.builtin.set_fact:
     run__datahub_subnet_ids: "{{ infra__azure_subnets }}"
+
+- name: Set fact for Azure NFS Mount
+  when: infra__azure_nfs_mount is defined
+  ansible.builtin.set_fact:
+    run__azure_nfs_mount: "{{ infra__azure_nfs_mount }}"

--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -46,10 +46,10 @@
     governance: "{{ __ml_config_item.raw.governance | default(omit) }}"
     metrics: "{{ __ml_config_item.raw.metrics | default(omit) }}"
     database: "{{ __ml_config_item.raw.database | default(omit) }}"
-    nfs: "{{ __ml_config_item.raw.nfs | default(omit) }}"
+    nfs: "{{ __ml_config_item.nfs | default(omit) }}"
     nfs_version: "{{ __ml_config_item.raw.nfs_version | default(omit) }}"
     ip_addresses: "{{ __ml_config_item.raw.ip_addresses | default(omit) }}"
-    public_loadbalancer: "{{ __ml_config_item.raw.public_loadbalancer | default(run__public_endpoint_access) | default(omit) }}"
+    public_loadbalancer: "{{ __ml_config_item.raw.public_loadbalancer | default(omit) }}"
     storage: "{{ __ml_config_item.raw.storage | default(omit) }}"
   loop_control:
     loop_var: __ml_config_item

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -16,7 +16,7 @@
 
 - name: Execute CDP OpDB teardown
   when:
-    - run__include_opdb
+    - run__include_opdb or run__force_teardown | bool
     - run__opdb_configs is defined
     - run__opdb_configs | length > 0
   cloudera.cloud.opdb:
@@ -35,7 +35,7 @@
 - name: Execute CDP DW cluster teardown
   register: __dw_teardown_info
   when:
-    - run__include_dw
+    - run__include_dw or run__force_teardown | bool
     - run__env_info.environments | length > 0
     - run__env_info.environments[0].descendants.dw | length > 0
   cloudera.cloud.dw_cluster:
@@ -47,7 +47,8 @@
 - name: Execute CDP Dataflow teardown
   register: __df_teardown_info
   when:
-    - run__include_df
+    - run__include_df or run__force_teardown | bool
+    - run__df_env_info is defined and run__df_env_info.services is defined
     - run__df_env_info.services | length > 0
   cloudera.cloud.df:
     name: "{{ __df_teardown_req_item.crn }}"
@@ -61,7 +62,7 @@
 
 - name: Execute CDP ML Workspace teardown
   when:
-    - run__include_ml
+    - run__include_ml or run__force_teardown | bool
     - run__ml_configs is defined
     - run__ml_configs | length > 0
   cloudera.cloud.ml:
@@ -80,7 +81,7 @@
 
 - name: Execute CDP Datahub teardown
   when:
-    - run__include_datahub
+    - run__include_datahub or run__force_teardown | bool
     - run__datahub_configs is defined
     - run__datahub_configs | length > 0
   cloudera.cloud.datahub_cluster:


### PR DESCRIPTION
Dependent on:
https://github.com/cloudera-labs/cdpy/pull/26
https://github.com/cloudera-labs/cloudera.cloud/pull/24

Add explicit test for Azure Storage Account being unavailable for use in this deployment
remove duplicate usage of __azure_netapp_vol_info as variable
Handle edge cases for preparation of Netapp NFS Mount when deploying ML automatically on Azure
Introduce wait and retry controls for handling Azure eventual consistency when negotiating between Ansible Controller, Azure Control Plane, and CDP Control Plane
Move default Azure minimal policy json from private gist to cloudera-labs snippets
Correct Azure App name where sometimes referred to with http:// header and sometimes not, resulting in idempotence failures. Oops.
Introduce more robust validations that Service principals and other objects created by az CLI are populated as expected
Ensure that Azure objects are consistently bound to the Azure namespace created from the name_prefix
Provide more user friendly errors when Azure App and Service Principal creation doesn't go as planned
Add tunnel and public endpoint control support to Azure Environment creation in line with AWS offering
Fix ML submission preparation to include nfs information following existing combination patterns
Swap order of Runtime initialization tasks to handle provider-specific tasks before general tasks, to allow Azure-specific values to be populated. No impact on other implementations
Explicitly derive Azure NFS Mount information in Runtime deployment from earlier Infrastructure deployment steps
Fix purge teardown edgecase where child services are not deleted if at least one child service is not present in the Definition. Now they are removed if purge is set and any are found regardless of provided Definition plan.

Meta-changelist:
Fix formatting in cloud.datahub_template_info
Add retry to address intermittent failure in datahub_template_info listing of datahub templates in CDP 7.2.10
cdpy now recognises that CML deployments may fail during provisioning and responds accordingly
cdpy will now automatically retry Azure cross-account credential creation in CDP when receiving eventual consistency errors

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>