### PR TITLE
FreeIPA and DataLake Scaling

### DIFF
--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -80,9 +80,11 @@ plat__cdp_iam_user_group_name:                "{{ env.cdp.user_group.name | defa
 plat__cdp_iam_user_group_roles:               "{{ env.cdp.user_group.roles | default([plat__cdp_iam_identities.env_user]) }}"
 plat__cdp_iam_user_group_resource_roles:      "{{ env.cdp.user_group.resource_roles | default(plat__cdp_iam_user_group_resource_roles_default) }}"
 
+plat__env_freeipa:                            "{{ env.freeipa.instance_count | default(env.enable_ha | default(false) | ternary(3, 2)) }}"
+
 plat__datalake_name:                          "{{ common__datalake_name }}"
 plat__datalake_version:                       "{{ env.datalake.version | default(omit) }}"
-plat__datalake_scale:                         "{{ env.datalake.scale | default(omit) }}"
+plat__datalake_scale:                         "{{ env.datalake.scale | default(env.enable_ha | default(false) | ternary('MEDIUM_DUTY_HA', 'LIGHT_DUTY')) }}"
 plat__datalake_user_sync:                     "{{ env.datalake.user_sync | default(True) }}"
 
 plat__cdp_xaccount_external_id:               "{{ env.cdp.cross_account.external_id | default(False) }}"

--- a/roles/platform/tasks/setup_aws_env.yml
+++ b/roles/platform/tasks/setup_aws_env.yml
@@ -33,3 +33,5 @@
     tunnel: "{{ plat__tunnel }}"
     endpoint_access_scheme: "{{ plat__endpoint_access_scheme | default(omit) }}"
     endpoint_access_subnets: "{{ plat__aws_public_subnet_ids | default(omit) }}"
+    freeipa:
+      instanceCountByGroup: "{{ plat__env_freeipa }}"

--- a/roles/platform/tasks/setup_azure_env.yml
+++ b/roles/platform/tasks/setup_azure_env.yml
@@ -33,3 +33,5 @@
     subnet_ids: "{{ plat__azure_subnets }}"
     public_ip: "{{ plat__public_endpoint_access }}"
     tags: "{{ plat__tags }}"
+    freeipa:
+      instanceCountByGroup: "{{ plat__env_freeipa }}"

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -32,3 +32,5 @@
     tunnel: "{{ plat__tunnel }}"
     workload_analytics: "{{ plat__workload_analytics }}"
     tags: "{{ plat__tags }}"
+    freeipa:
+      instanceCountByGroup: "{{ plat__env_freeipa }}"


### PR DESCRIPTION
Updates

- Add parameters to env setup for AWS/AZ/GCP for passing FreeIPA instance number
- Add defaults for Datalake scale and number of freeipa instances
- Add "enable_ha" variable to quick set DL to medium duty and number of freeipa instances to 3
- Allow for explicit setting of datalake scale and number of freeipa instances

Note: "LIGHT DUTY" is now defined as LIGHT_DUTY datalake and 2 freeipa nodes. "MEDIUM DUTY" is now defined as MEDIUM_DUTY_HA datalake and 3 freeipa nodes.

PR in conjunction with cloudera.cloud PR: [cloudera.cloud/pull/26](https://github.com/cloudera-labs/cloudera.cloud/pull/26)