### PR TITLE
Improve GCP teardown idempotence

### DIFF
--- a/roles/platform/tasks/initialize_gcp.yml
+++ b/roles/platform/tasks/initialize_gcp.yml
@@ -58,6 +58,7 @@
   failed_when:
     - __gcp_xaccount_sa_discovered.rc == 1
     - "'NOT_FOUND:' not in __gcp_xaccount_sa_discovered.stderr"
+    - "'Permission iam.serviceAccountKeys.list' not in __gcp_xaccount_sa_discovered.stderr"
   command: >
     gcloud iam service-accounts keys list
     --iam-account "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"


### PR DESCRIPTION
GCP may throw a permission issue if you attempt to list a missing service account key, which should be ignored during teardown

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>