### PR TITLE
Update ML Workspace setup to use definition of a single instance group

### DIFF
--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -40,7 +40,7 @@
   cloudera.cloud.ml:
     name: "{{ __ml_config_item.name }}"
     env: "{{ run__env_name }}"
-    k8s_request: "{{ __ml_config_item.k8s_request if __ml_config_item.k8s_request.instanceGroups | length > 1 else omit }}"
+    k8s_request: "{{ __ml_config_item.k8s_request if __ml_config_item.k8s_request.instanceGroups | length > 0 else omit }}"
     tls: "{{ __ml_config_item.raw.tls | default(omit) }}"
     monitoring: "{{ __ml_config_item.raw.monitoring | default(omit) }}"
     governance: "{{ __ml_config_item.raw.governance | default(omit) }}"


### PR DESCRIPTION
We found that when creating a ML workspace only getting the default instance group was provisioned.

We identified that the conditional at [roles/runtime/tasks/setup_base.yml#L44](https://github.com/cloudera-labs/cloudera.exe/blob/main/roles/runtime/tasks/setup_base.yml#L44) caused this by omitting the instance group when only 1 instance group was defined.

The committed change fixes this. The change was tested with this below ML definition:

```yaml
ml:
  definitions:
    - name: "{{ name_prefix }}-ml"
      tls: yes
      monitoring: yes
      governance: yes
      metrics: yes
      public_loadbalancer: yes
      instance_groups:
        - name: cml
          instanceCount: 0
          instanceType: "m5.4xlarge"
          instanceTier: "ON_DEMAND"
          autoscaling:
            minInstances: 0
            maxInstances: 10
            enabled: yes
          rootVolume:
            size: 100
```

Signed-off-by: Jim Enright <jenright@cloudera.com>