### PR TITLE
Correcting Idbroker Role policy definitions for AWS

### DIFF
--- a/roles/platform/tasks/setup_aws_authz.yml
+++ b/roles/platform/tasks/setup_aws_authz.yml
@@ -149,6 +149,7 @@
       service: ec2.amazonaws.com
       policies:
         - "{{ plat__aws_idbroker_policy_name }}"
+        - "{{ plat__aws_log_location_policy_name }}"
     - name: "{{ plat__aws_log_role_name }}"
       description: CDP Log
       service: ec2.amazonaws.com


### PR DESCRIPTION
Signed-off-by: Anurag Patro <anurag.patro@cloudera.com>

Following IDBroker Role definition mentioned in [Minimal setup for cloud storage
](https://docs.cloudera.com/cdp/latest/requirements-aws/topics/mc-idbroker-minimum-setup.html)
Not a breaker, recommended definition mentioned above is checked for in cdpctl tool, hence the change. 
for issue https://github.com/cloudera-labs/cloudera.exe/issues/36