### PR TITLE
Fix L1 networking teardown when purge is used

### DIFF
--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -70,6 +70,27 @@
               retries: 120
               delay: 10
 
+        - name: Remove discovered AWS NAT Gateways
+          register: __infra_aws_nat_remove_result
+          when:
+            - __infra_aws_nat_gateways is defined
+            - __infra_aws_nat_gateways.result is defined
+            - __infra_aws_nat_gateways.result | length > 0
+          community.aws.ec2_vpc_nat_gateway:
+            state: absent
+            region: "{{ infra__region }}"
+            wait: true
+            nat_gateway_id: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
+            release_eip: true
+          loop_control:
+            label: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
+            loop_var: __infra_nat_gateway_remove_item
+          loop: "{{ __infra_aws_nat_gateways.result }}"
+          failed_when:
+            - "'rc' in __infra_aws_nat_remove_result"
+            - __infra_aws_nat_remove_result.rc != 0
+            - "'InvalidAllocationID.NotFound' not in __infra_aws_nat_remove_result.module_stderr"
+
         - name: Remove discovered AWS Network Adapters
           when:
             - __infra_vpc_enis is defined
@@ -114,24 +135,6 @@
                 loop_var: __security_group_purge_item
                 label: "{{ __security_group_purge_item.group_name }}"
               loop: "{{ __infra_aws_sgs.security_groups }}"
-
-        - name: Remove discovered AWS NAT Gateways
-          register: __infra_aws_nat_remove_result
-          when:
-            - __infra_aws_nat_gateways is defined
-            - __infra_aws_nat_gateways.result is defined
-            - __infra_aws_nat_gateways.result | length > 0
-          community.aws.ec2_vpc_nat_gateway:
-            state: absent
-            region: "{{ infra__region }}"
-            wait: true
-            nat_gateway_id: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
-            release_eip: true
-          loop_control:
-            label: "{{ __infra_nat_gateway_remove_item.nat_gateway_id }}"
-            loop_var: __infra_nat_gateway_remove_item
-          loop: "{{ __infra_aws_nat_gateways.result }}"
-          failed_when: __infra_aws_nat_remove_result.rc != 0 and 'InvalidAllocationID.NotFound' not in __infra_aws_nat_remove_result.module_stderr
 
         - name: Remove discovered AWS VPC Subnets
           when:


### PR DESCRIPTION
When calling purge with an L1 deployment, or particularly when NAT gateways are deployed with attached ENI, it is necessary to remove the nat gateways before the ENI cleanup is called or teardown fails

community.aws.ec2_vpc_nat_gateway may fail to return an rc code during normal removal, so we add a check that it is present during error conditions

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>