### PR TITLE
Allow optional deletion of GCP Custom roles during teardown

### DIFF
--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -53,6 +53,7 @@ plat__vpc_private_subnets:                    "{{ common__vpc_private_subnet_cid
 # Plat
 plat__teardown_deletes_policies:              "{{ env.teardown.delete_policies | default(True) }}"
 plat__teardown_deletes_roles:                 "{{ env.teardown.delete_roles | default(True) }}"
+plat__teardown_deletes_gcp_custom_roles:      "{{ env.teardown.delete_gcp_custom_roles | default(plat__teardown_deletes_roles) }}"
 plat__teardown_deletes_xaccount:              "{{ env.teardown.delete_cross_account | default(True) }}"
 plat__teardown_deletes_credential:            "{{ env.teardown.delete_credential | default(True) }}"
 plat__teardown_deletes_admin_group:           "{{ env.teardown.delete_admin_group | default(True) }}"

--- a/roles/platform/tasks/setup_gcp_authz.yml
+++ b/roles/platform/tasks/setup_gcp_authz.yml
@@ -56,32 +56,51 @@
     name: "{{ plat__xacccount_credential_name }}"
     secret: "{{ __gcp_creds_tmpdir.path }}/{{ plat__gcp_xaccount_identity_name }}-gcp-cred.json"
 
-- name: Create other GCP Roles
+- name: Create Custom GCP Log Role
   register: __gcp_role_creation_info
-  loop_control:
-    loop_var: __gcp_role_item
-  loop:
-    - name: "{{ plat__gcp_log_role_name }}"
-      perms: "{{ plat__gcp_log_role_perms }}"
   google.cloud.gcp_iam_role:
-    name: "{{ __gcp_role_item.name }}"
-    title: "{{ __gcp_role_item.name }}"
-    description: "{{ __gcp_role_item.name }}"
-    included_permissions: "{{ __gcp_role_item.perms }}"
+    name: "{{ plat__gcp_log_role_name }}"
+    title: "{{ plat__gcp_log_role_name }}"
+    description: "{{ plat__gcp_log_role_name }}"
+    included_permissions: "{{ plat__gcp_log_role_perms }}"
     project: "{{ plat__gcp_project }}"
     state: present
+  failed_when:
+    - __gcp_role_creation_info.msg is defined
+    - "'GCP returned error' in __gcp_role_creation_info.msg"
+    - "'marked for deletion' not in __gcp_role_creation_info.msg"
 
-- name: Undelete custom role if name is being reused before removal from GCP
-  loop: "{{ __gcp_role_creation_info.results }}"
-  loop_control:
-    loop_var: __gcp_role_undelete_item
+- name: Undelete Custom Log role if recently marked for deletion
   when:
-    - __gcp_role_undelete_item.deleted is defined
-    - __gcp_role_undelete_item.deleted | bool
+    - __gcp_role_creation_info.deleted is defined
+    - __gcp_role_creation_info.deleted | bool
   ansible.builtin.command: >
     gcloud iam roles
     undelete {{ plat__gcp_log_role_name }}
     --project={{ plat__gcp_project }}
+  register: __gcp_role_undelete
+
+- name: Fetch resulting Custom GCP Log Role status
+  ansible.builtin.command: >
+    gcloud iam roles
+    describe {{ plat__gcp_log_role_name }}
+    --project={{ plat__gcp_project }}
+  register: __gcp_custom_log_role_info
+  failed_when:
+    - __gcp_custom_log_role_info.rc == 1
+    - "'NOT_FOUND:' not in __gcp_custom_log_role_info.stderr"
+
+- name: Fail when custom GCP Log Role is not available
+  ansible.builtin.assert:
+    that:
+      - "'includedPermissions:' in __gcp_custom_log_role_info.stdout"
+      - "'NOT_FOUND' not in __gcp_custom_log_role_info.stderr"
+    quiet: yes
+    fail_msg: |
+      Custom Log Role {{ plat__gcp_log_role_name }} could not be created or undeleted.
+      It is likely that the unique role_id was marked for deletion recently and you are in the GCloud no-reuse window.
+      This no-reuse of a role_id window is typically somewhere from 7-14 days after initial deletion, and lasts 30 days.
+      Please use a different name for your custom Role.
 
 - name: Create Operational GCP Service Accounts
   register: __gcp_identity_info

--- a/roles/platform/tasks/teardown_gcp_authz.yml
+++ b/roles/platform/tasks/teardown_gcp_authz.yml
@@ -39,19 +39,15 @@
     project: "{{ plat__gcp_project }}"
     state: absent
 
-- name: Tear down GCP Roles
-  when: plat__teardown_deletes_roles
+- name: Tear down GCP Custom Log Role
+  when: plat__teardown_deletes_gcp_custom_roles
   register: __gcp_role_teardown
   failed_when:
-    - plat__teardown_deletes_roles.msg is defined
-    - "'GCP returned error' in plat__teardown_deletes_roles.msg"
-    - "'it is already deleted' not in plat__teardown_deletes_roles.msg"
-  loop_control:
-    loop_var: __gcp_role_item
-  loop:
-    - "{{ plat__gcp_log_role_name }}"
+    - __gcp_role_teardown.msg is defined
+    - "'GCP returned error' in __gcp_role_teardown.msg"
+    - "'it is already deleted' not in __gcp_role_teardown.msg"
   google.cloud.gcp_iam_role:
-    name: "{{ __gcp_role_item }}"
+    name: "{{ plat__gcp_log_role_name }}"
     project: "{{ plat__gcp_project }}"
     state: absent
 


### PR DESCRIPTION
When a custom role on GCP is 'deleted', it is actually only marked for deletion and may not be fully removed for 7-14days, during which time it may be undeleted. The role already handles this option.
However once it is fully deleted, the same name (role_id) may not be reused for 30 days, meaning that a deleted custom role is ambiguously unavailable for the 37-44 days following a deletion request.
Therefore in this change, we break out the GCP custom roles to a separate deletion flag, which defaults to yes.
We also handle undelete, and failed undelete elegantly with a meaningful error message.
We also remove the extraneous loop on the custom role, as there is only a single one handled.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>