### PR TITLE
Extensible tagging for Cloudera Experiences

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -109,12 +109,20 @@ For example, to add a pre-deploy role:
             - plat
             - run
             - animals
+            - ml
+            - dw
+            - opdb
+            - dh
       tags:
         - validate
         - infra
         - plat
         - run
         - animals
+        - ml
+        - dw
+        - opdb
+        - dh
     - name: Import the core Runlevels (and their tags)
       ansible.builtin.import_role:
         name: cloudera.exe.sequence 
@@ -158,12 +166,20 @@ For example, adding an explicit `install` tag to execute the [Installation](runl
             - plat
             - run
             - install
+            - ml
+            - dw
+            - opdb
+            - dh
       tags:
         - validate
         - infra
         - plat
         - run
         - install
+        - ml
+        - dw
+        - opdb
+        - dh
     
     - name: Validate Platform Configuration
       ansible.builtin.include_role:
@@ -175,11 +191,19 @@ For example, adding an explicit `install` tag to execute the [Installation](runl
             - plat
             - run
             - install
+            - ml
+            - dw
+            - opdb
+            - dh
       tags:
         - validate
         - plat
         - run
         - install
+        - ml
+        - dw
+        - opdb
+        - dh
 
     - name: Validate Runtime Configuration
       ansible.builtin.include_role:
@@ -190,10 +214,18 @@ For example, adding an explicit `install` tag to execute the [Installation](runl
             - validate
             - run
             - install
+            - ml
+            - dw
+            - opdb
+            - dh
       tags:
         - validate
         - run
         - install
+        - ml
+        - dw
+        - opdb
+        - dh
 
     - name: Validate Installation Configuration
       ansible.builtin.include_role:

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -59,6 +59,7 @@
 
 - name: Prepare for CDP Datahub clusters
   when: run__include_datahub
+  tags: dh
   block:
     - name: Retrieve Image Catalog File
       ansible.builtin.uri:
@@ -121,6 +122,7 @@
       loop: "{{ run__datahub_configs }}"
 
 - name: Prepare for CDP OpDB experiences
+  tags: opdb
   when: run__include_opdb
   block:
     - name: Construct OpDB Configurations
@@ -136,6 +138,7 @@
         label: "{{ config.name }}"
 
 - name: Prepare for CDP ML Workspace experiences
+  tags: ml
   when: run__include_ml
   block:
     - name: Construct CDP ML Workspace configurations

--- a/roles/runtime/tasks/initialize_setup.yml
+++ b/roles/runtime/tasks/initialize_setup.yml
@@ -16,6 +16,16 @@
 
 - name: Include provider-specific tasks to initialize Runtime setup
   ansible.builtin.include_tasks: "initialize_setup_{{ run__infra_type }}.yml"
+  tags:
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Initialize CDP Runtime setup
   ansible.builtin.include_tasks: "initialize_base.yml"
+  tags:
+    - ml
+    - dw
+    - opdb
+    - dh

--- a/roles/runtime/tasks/setup.yml
+++ b/roles/runtime/tasks/setup.yml
@@ -16,6 +16,14 @@
 
 - name: Include Tasks to Setup CDP Public Runtimes
   ansible.builtin.include_tasks: "setup_base.yml"
+  tags:
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Include Tasks to Setup provider-specific CDP Public Runtimes
   ansible.builtin.include_tasks: "setup_{{ run__infra_type }}.yml"
+  tags:
+    - dw
+    - dh

--- a/roles/runtime/tasks/setup_aws.yml
+++ b/roles/runtime/tasks/setup_aws.yml
@@ -16,6 +16,7 @@
 
 - name: Set up AWS EC2 metadata for CDP Datahubs
   when: run__include_datahub
+  tags: dh
   block:
     - name: Retrieve AWS EC2 instance details
       community.aws.ec2_instance_info:
@@ -36,6 +37,7 @@
 
 - name: Setup CDP DW cluster on AWS
   when: run__include_dw
+  tags: dw
   block:
     - name: Execute CDP DW cluster setup
       cloudera.cloud.dw_cluster:

--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -178,8 +178,8 @@
 - name: Wait for CDP Dataflow deployment to complete
   when: run__include_df
   tags: df
-  cloudera.cloud.df:
-    name: "{{ run__cdp_env_crn }}"
+  cloudera.cloud.df_service:
+    env_crn: "{{ run__cdp_env_crn }}"
     wait: yes
 
 - name: Create CDP DE Virtual clusters

--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -16,6 +16,7 @@
 
 - name: Request CDP Datahub deployments
   when: run__include_datahub
+  tags: dh
   cloudera.cloud.datahub_cluster:
     name: "{{ __datahub_config_item.name }}"
     env: "{{ run__env_name }}"
@@ -37,6 +38,7 @@
 
 - name: Execute CDP ML Workspace experiences setup
   when: run__include_ml
+  tags: ml
   cloudera.cloud.ml:
     name: "{{ __ml_config_item.name }}"
     env: "{{ run__env_name }}"
@@ -89,6 +91,7 @@
 
 - name: Execute CDP OpDB setup
   when: run__include_opdb
+  tags: opdb
   cloudera.cloud.opdb:
     name: "{{ __opdb_config_item.name }}"
     env: "{{ run__env_name }}"
@@ -104,8 +107,9 @@
 
 - name: Execute CDP Dataflow setup
   when: run__include_df
-  cloudera.cloud.df_service:
-    env_crn: "{{ run__cdp_env_crn }}"
+  tags: df
+  cloudera.cloud.df:
+    name: "{{ run__cdp_env_crn }}"
     nodes_min: "{{ run__df_nodes_min }}"
     nodes_max: "{{ run__df_nodes_max }}"
     public_loadbalancer: "{{ run__df_public_loadbalancer }}"
@@ -118,6 +122,7 @@
 
 - name: Wait for CDP Datahub deployments to complete
   when: run__include_datahub
+  tags: dh
   ansible.builtin.async_status:
     jid: "{{ __datahub_build_item.ansible_job_id }}"
   loop_control:
@@ -131,6 +136,7 @@
 
 - name: Wait for CDP ML Workspace experiences to complete
   when: run__include_ml
+  tags: ml
   ansible.builtin.async_status:
     jid: "{{ __ml_build.ansible_job_id }}"
   loop_control:
@@ -157,6 +163,7 @@
 
 - name: Wait for CDP OpDB deployments to complete
   when: run__include_opdb
+  tags: opdb
   ansible.builtin.async_status:
     jid: "{{ __opdb_build.ansible_job_id }}"
   loop_control:
@@ -170,8 +177,9 @@
 
 - name: Wait for CDP Dataflow deployment to complete
   when: run__include_df
-  cloudera.cloud.df_service:
-    env_crn: "{{ run__cdp_env_crn }}"
+  tags: df
+  cloudera.cloud.df:
+    name: "{{ run__cdp_env_crn }}"
     wait: yes
 
 - name: Create CDP DE Virtual clusters

--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -108,8 +108,8 @@
 - name: Execute CDP Dataflow setup
   when: run__include_df
   tags: df
-  cloudera.cloud.df:
-    name: "{{ run__cdp_env_crn }}"
+  cloudera.cloud.df_service:
+    env_crn: "{{ run__cdp_env_crn }}"
     nodes_min: "{{ run__df_nodes_min }}"
     nodes_max: "{{ run__df_nodes_max }}"
     public_loadbalancer: "{{ run__df_public_loadbalancer }}"

--- a/roles/runtime/tasks/validate_base.yml
+++ b/roles/runtime/tasks/validate_base.yml
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 - name: Check OpDB database names
+  tags: opdb
   when:
     - run__include_opdb
     - "'name' in __opdb_definition"
@@ -29,6 +30,7 @@
   loop: "{{ run__opdb_definitions }}"
 
 - name: Check Datahub names
+  tags: dh
   when:
     - run__include_datahub
     - "'name' in __datahub_definition"

--- a/roles/sequence/tasks/main.yml
+++ b/roles/sequence/tasks/main.yml
@@ -26,12 +26,20 @@
         - infra
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - validate
     - infra
     - plat
     - run
-
+    - ml
+    - dw
+    - opdb
+    - dh
+  
 - name: Validate Platform Configuration
   ansible.builtin.include_role:
     name: cloudera.exe.platform
@@ -41,10 +49,18 @@
         - validate
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - validate
     - plat
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Validate Runtime Configuration
   ansible.builtin.include_role:
@@ -54,9 +70,17 @@
       tags:
         - validate
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - validate
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Initialize Runtime Teardown
   ansible.builtin.include_role:
@@ -147,11 +171,19 @@
         - infra
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - init
     - infra
     - plat
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Setup Infrastructure
   when: sequence__setup_infra | bool
@@ -163,10 +195,18 @@
         - infra
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - infra
     - plat
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Initialize Platform Setup
   when: sequence__setup_plat | bool
@@ -178,10 +218,18 @@
         - init
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - init
     - plat
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Setup Platform
   when: sequence__setup_plat | bool
@@ -192,9 +240,17 @@
       tags:
         - plat
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - plat
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Initialize Runtime Setup
   when: sequence__setup_runtime | bool
@@ -205,9 +261,17 @@
       tags:
         - init
         - run
+        - ml
+        - dw
+        - opdb
+        - dh
   tags:
     - init
     - run
+    - ml
+    - dw
+    - opdb
+    - dh
 
 - name: Setup Runtime
   when: sequence__setup_runtime | bool
@@ -219,3 +283,7 @@
         - run
   tags:
     - run
+    - ml
+    - dw
+    - opdb
+    - dh


### PR DESCRIPTION
Enabling extensible execution of the Cloudera Experiences by use of tags.

Each experience has their own tag: ml, opdb, dh and df.

You can exclude experiences by use of "--skip-tags". For exapmle `ansible-playbook main.yml -e @examples/sandbox/config.yml -t run --skip-tags ml, opdb, dh`. This will skip the creation of ML, OpDB and the DH. 