### PR TITLE
Enhancement to sudoers role to add groups and work with user sync

### DIFF
--- a/roles/sudoers/defaults/main.yml
+++ b/roles/sudoers/defaults/main.yml
@@ -21,9 +21,13 @@
 # Variables used as inputs in main.yml
 sudoers__env_admin_password:                     "{{ common__env_admin_password }}"
 
-sudoers__sudo_group_name:                        sudoers
-sudoers__sudo_group_users:                       []
-# Flag to determine if we want to remove (=True) or retain (=False) existing users in sudoers group
-sudoers__purge_users_in_group:                   False                         
+# sudoers__sudo_group_name:                        sudoers
+sudoers__sudo_users:                       []
+sudoers__sudo_groups:                      [] # the groups that are members of the sudo_rule
+
+# Flag to determine if we want to remove (=True) or retain (=False) existing users in sudo rule
+sudoers__purge_users:                   False                         
+# Flag to determine if we want to remove (=True) or retain (=False) existing group members in sudo rule
+sudoers__purge_groups:                  False                         
 
 sudoers__sudorule_name:                          admin_all_rule

--- a/roles/sudoers/meta/main.yml
+++ b/roles/sudoers/meta/main.yml
@@ -15,8 +15,9 @@
 galaxy_info:
   author: Jim Enright (jenright@cloudera.com)
   description: >
-    Add specified users to FreeIPA sudoers group and create a passwordless sudo rule for the group. 
-    Existing group members can be purged or retained depending on the value of the sudoers__purge_users_in_group flag.
+    Create a passwordless sudo rule and add specified users and/or groups as members to this rule. 
+    Existing group members and users can be purged or retained depending on the value of 
+    the sudoers__purge_groups and sudoers__purge_users flags.
   company: Cloudera
   license: Apache-2.0
 

--- a/roles/sudoers/tasks/main.yml
+++ b/roles/sudoers/tasks/main.yml
@@ -14,38 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# If don't want to purge existing users from the FreeIPA group,
-# we'll query the group to get current users 
+# If don't want to purge existing users (and groups) from the FreeIPA sudo rule,
+# we'll query the rule to get current users (and groups)
 - name: Query sudoers group for list of users
-  when: not sudoers__purge_users_in_group
+  when: (not sudoers__purge_users) or (not sudoers__purge_groups)
   block:
-    # Note - below creates the group if it doesn't already exist
-    - name: Create or query the sudoers group
-      community.general.ipa_group:
+    # Note - below creates the rule if it doesn't already exist
+    - name: Create or query the sudo rule
+      community.general.ipa_sudorule:
         ipa_user: "{{ sudoers__env_admin_username }}"
         ipa_pass: "{{ sudoers__env_admin_password }}"
-        name: "{{ sudoers__sudo_group_name }}"
+        name: "{{ sudoers__sudorule_name }}"
         state: present
-      register: sudoers_group
+      register: sudo_rule_details
 
-    - name: Set facts for current user members of the group
+    - name: Set facts for current user and group members of the sudo rule
       ansible.builtin.set_fact:
-        __sudo_existing_group_users: "{{ sudoers_group.group.member_user | default([]) }}"
+        __sudo_existing_users: "{{ sudo_rule_details.sudorule.memberuser_user | default([]) }}"
+        __sudo_existing_groups: "{{ sudo_rule_details.sudorule.memberuser_group | default([]) }}"
 
-# Final list of users to add to sudoers group -
+# Final list of users and groups to add to sudoers group -
 # either combined with existing group members or overrides
 - name: Create list of users to add to sudoers group
   ansible.builtin.set_fact:
-    __sudo_group_users: "{{ sudoers__sudo_group_users | union(__sudo_existing_group_users) if not sudoers__purge_users_in_group else sudoers__sudo_group_users }}"
-
-# Create a FreeIPA group for sudo and add users
-- name: Add users to the sudoers group
-  community.general.ipa_group:
-    ipa_user: "{{ sudoers__env_admin_username }}"
-    ipa_pass: "{{ sudoers__env_admin_password }}"
-    name: "{{ sudoers__sudo_group_name }}"
-    user: "{{ __sudo_group_users }}"
-    state: present
+    __sudo_users: "{{ sudoers__sudo_users | union(__sudo_existing_users) if not sudoers__purge_users else sudoers__sudo_users }}"
+    __sudo_groups: "{{ sudoers__sudo_groups | union(__sudo_existing_groups) if not sudoers__purge_groups else sudoers__sudo_groups }}"
 
 # Create FreeIPA sudo rule
 - name: Add sudo rule for passwordless sudo
@@ -56,6 +49,6 @@
     cmdcategory: all
     hostcategory: all
     sudoopt: "!authenticate"
-    usergroup:
-      - "{{ sudoers__sudo_group_name }}"
+    user: "{{ __sudo_users }}"
+    usergroup: "{{ __sudo_groups }}"
     state: present

--- a/roles/sudoers/tasks/teardown.yml
+++ b/roles/sudoers/tasks/teardown.yml
@@ -21,12 +21,3 @@
     ipa_pass: "{{ sudoers__env_admin_password }}"
     name: "{{ sudoers__sudorule_name }}"
     state: absent
-
-# Remove the FreeIPA group for sudo
-- name: Remove sudoers group
-  community.general.ipa_group:
-    ipa_user: "{{ sudoers__env_admin_username }}"
-    ipa_pass: "{{ sudoers__env_admin_password }}"
-    name: "{{ sudoers__sudo_group_name }}"
-    state: absent
-  register: sudoers_group


### PR DESCRIPTION
Two changes to the cloudera.exe.sudoers roles are included as part of this PR:

1. An enhancement to add a CDP group to the FreeIPA sudo rule. We can now specify an existing CDP group to add to the sudo rule in addition to individual users.
2. As part of the above testing, we found that the FreeIPA `sudoers` group created as part of this role was wiped when we did a User Sync in CDP. To fix this the code is changed to assign the groups and users directly to the sudo rule (rather than first creating a "native" FreeIPA group).

Have tested the different combinations of this and confirmed that sudo rule works as expected (including following the CDP User Sync).

Signed-off-by: Jim Enright <jenright@cloudera.com>