### PR TITLE
AWS VPC Endpoint Support

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -227,6 +227,7 @@ globals:
     table:
     user:
     vpc:
+    vpce:
   name_prefix:
   namespace_cdp:
   region:
@@ -264,6 +265,7 @@ infra:
       tags:
     storage:
       tags:
+    private_endpoints:
   azure:
     metagroup:
       name:
@@ -312,6 +314,9 @@ infra:
       name:
       suffix:
     knox:
+      name:
+      suffix:
+    vpce:
       name:
       suffix:
   storage:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -34,6 +34,7 @@ common__public_suffix:                    "{{ globals.labels.public | default('p
 common__private_suffix:                   "{{ globals.labels.private | default('pvt') }}"
 common__security_group_knox_suffix:       "{{ globals.labels.knox | default('knox') }}"
 common__security_group_default_suffix:    "{{ globals.labels.default | default('default') }}"
+common__security_group_vpce_suffix:       "{{ globals.labels.vpce | default('vpce') }}"
 common__role_suffix:                      "{{ globals.labels.role | default('role') }}"
 common__policy_suffix:                    "{{ globals.labels.policy | default('policy') }}"
 common__storage_suffix:                   "{{ globals.labels.storage | default('storage') }}"
@@ -73,9 +74,11 @@ common__vpc_public_subnets_suffix:        "{{ infra.vpc.private_subnets_suffix |
 
 common__security_group_knox_name:         "{{ infra.security_group.knox.name | default([common__namespace, common__security_group_knox_name_suffix] | join('-')) }}"
 common__security_group_default_name:      "{{ infra.security_group.default.name | default([common__namespace, common__security_group_default_name_suffix] | join('-')) }}"
+common__security_group_vpce_name:         "{{ infra.security_group.vpce.name | default([common__namespace, common__security_group_vpce_name_suffix] | join('-')) }}"
 
 common__security_group_knox_name_suffix:    "{{ infra.security_group.knox.suffix | default(common__security_group_knox_suffix) }}"
 common__security_group_default_name_suffix: "{{ infra.security_group.default.suffix | default(common__security_group_default_suffix) }}"
+common__security_group_vpce_name_suffix:    "{{ infra.security_group.vpce.suffix | default(common__security_group_vpce_suffix) }}"
 
 common__ml_path:                          "{{ infra.storage.path.ml | default('datasci') }}"
 common__de_path:                          "{{ infra.storage.path.de | default('dataeng') }}"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -89,6 +89,7 @@ infra__aws_private_subnet_ids:      "{{ infra.aws.vpc.existing.private_subnet_id
 
 infra__security_group_knox_name:    "{{ common__security_group_knox_name }}"
 infra__security_group_default_name: "{{ common__security_group_default_name }}"
+infra__security_group_vpce_name:    "{{ common__security_group_vpce_name }}"
 
 infra__ml_deploy:                   "{{ common__include_ml }}"
 infra__ml_path:                     "{{ common__ml_path }}"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -114,6 +114,7 @@ infra__aws_nat_gateway_suffix:      "{{ infra.aws.vpc.nat_gateway.suffix | defau
 infra__aws_role_tags:               "{{ infra.aws.role.tags | default({}) }}"
 infra__aws_policy_tags:             "{{ infra.aws.policy.tags | default({}) }}"
 infra__aws_storage_tags:            "{{ infra.aws.storage.tags | default({}) }}"
+infra__aws_private_endpoints:       "{{ infra.aws.vpc.private_endpoints | default(common__tunnel) }}"
 
 # GCP
 infra__gcp_project:                 "{{ common__gcp_project }}"

--- a/roles/infrastructure/tasks/initialize_teardown_aws.yml
+++ b/roles/infrastructure/tasks/initialize_teardown_aws.yml
@@ -14,6 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: List VPC Endpoints
+  when: infra__aws_private_endpoints | bool
+  community.aws.ec2_vpc_endpoint_info:
+    region: "{{ infra__region }}"
+    filters:
+      vpc-id: "{{ infra__aws_vpc_id }}"
+  register: __infra_vpc_existing_endpoints
+
 - name: Discover AWS VPC dependencies for forced teardown
   when:
     - infra__force_teardown | bool

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -253,7 +253,7 @@
         state: present
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
-        tags: "{{ infra__tags | combine({ 'Name': 'vpce_sg' }, recursive=True) }}"
+        tags: "{{ infra__tags | combine({ 'Name': 'infra__security_group_vpce_name' }, recursive=True) }}"
         name: "{{ infra__security_group_vpce_name }}"
         description: "{{ infra__security_group_vpce_name }}"
         rules:

--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -243,3 +243,90 @@
   vars:
     knox: "results[?group_name=='{{ infra__security_group_knox_name }}'].group_id"
     default: "results[?group_name=='{{ infra__security_group_default_name }}'].group_id"
+
+
+- name: Setup AWS Private Endpoints
+  when: infra__aws_private_endpoints | bool
+  block:
+    - name: Create VPC Endpoint Security Group (Skip if infra__aws_private_endpoints is false)
+      amazon.aws.ec2_group:
+        state: present
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        tags: "{{ infra__tags | combine({ 'Name': 'vpce_sg' }, recursive=True) }}"
+        name: "{{ infra__security_group_vpce_name }}"
+        description: "{{ infra__security_group_vpce_name }}"
+        rules:
+          - proto: all
+            cidr_ip: "{{ infra__vpc_cidr }}"
+      register: __aws_vpce_security_group_info
+
+    - name: List the Route Tables for the AWS VPC (Skip if infra__aws_private_endpoints is false)
+      community.aws.ec2_vpc_route_table_info:
+        region: "{{ infra__region }}"
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+      register: __aws_route_table_list_again
+    
+    - name: Set fact for All Route Table IDs (Skip if infra__aws_private_endpoints is false)
+      ansible.builtin.set_fact:
+        infra__route_table_ids: "{{ infra__route_table_ids | default([]) | union([route_table_id]) }}"
+      vars:
+        route_table_id: "{{ __aws_route_tables.associations[0].route_table_id }}"
+      loop: "{{ __aws_route_table_list_again.route_tables }}"
+      loop_control:
+        label: "{{ __aws_route_tables.associations[0].route_table_id }}"
+        loop_var: __aws_route_tables
+
+    - name: Create Gateway VPC Endpoints (Skip if infra__aws_private_endpoints is false)
+      community.aws.ec2_vpc_endpoint:
+        state: present
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        service: "{{ __infra_gateway_vpc_endpoint }}"
+        route_table_ids: "{{ infra__route_table_ids }}"
+        tags: "{{ infra__tags | combine({ 'Name': infra__namespace + __infra_gateway_vpc_endpoint.split(infra__region)[1] }, recursive=True) }}"
+      vars:
+        route_table_id: "{{ route_tables.associations[0].route_table_id }}"
+      loop: "{{ infra__aws_gateway_vpc_private_endpoints }}"
+      loop_control:
+        loop_var: __infra_gateway_vpc_endpoint
+      register: __aws_gateway_vpc_endpoints
+
+    - name: Create Interface VPC Endpoints (Skip if infra__aws_private_endpoints is false)
+      community.aws.ec2_vpc_endpoint:
+        state: present
+        region: "{{ infra__region }}"
+        vpc_id: "{{ infra__aws_vpc_id }}"
+        service: "{{ __infra_interface_vpc_endpoint }}"
+        vpc_endpoint_type: Interface
+        wait: true
+        tags: "{{ infra__tags | combine({ 'Name': infra__namespace + __infra_interface_vpc_endpoint.split(infra__region)[1] }, recursive=True) }}"
+      loop: "{{ infra__aws_interface_vpc_private_endpoints }}"
+      loop_control:
+        loop_var: __infra_interface_vpc_endpoint
+      register: __aws_interface_vpc_endpoints
+
+    - name: List Default Security Group for VPC (Skip if infra__aws_private_endpoints is false)
+      amazon.aws.ec2_group_info:
+        filters:
+          vpc-id: "{{ infra__aws_vpc_id }}"
+          group-name:
+            - default
+      register: __aws_vpc_default_sg
+    
+    - name: Add Subnets and Security Groups to Interface VPC Endpoints (Skip if infra__aws_private_endpoints is false)
+      when:
+        - __aws_interface_vpc_endpoints is defined
+        - __aws_interface_vpc_endpoints.results is defined
+      command: >
+        aws ec2 modify-vpc-endpoint
+        --vpc-endpoint-id {{ __infra_vpce_loop_var.result.vpc_endpoint_id }}
+        --add-subnet-ids {{ infra__aws_public_subnet_ids | join(' ') }} 
+        --add-security-group-ids {{ __aws_vpce_security_group_info.group_id }}
+        --remove-security-group-ids {{ __aws_vpc_default_sg.security_groups[0].group_id }}
+        --private-dns-enabled
+      loop_control:
+        label: "{{ __infra_vpce_loop_var.result.vpc_endpoint_id | default('') }}"  # Default empty string to avoid ansible label undef error
+        loop_var: __infra_vpce_loop_var
+      loop: "{{ __aws_interface_vpc_endpoints.results }}"

--- a/roles/infrastructure/tasks/teardown_aws_network.yml
+++ b/roles/infrastructure/tasks/teardown_aws_network.yml
@@ -39,6 +39,33 @@
     - name: Remove all AWS VPC networking resources
       when: infra__force_teardown | bool
       block:
+        - name: List VPC Endpoints
+          community.aws.ec2_vpc_endpoint_info:
+            region: "{{ infra__region }}"
+            filters:
+              vpc-id: "{{ infra__aws_vpc_id }}"
+          register: existing_endpoints
+        
+        - name: Delete VPC Endpoints
+          community.aws.ec2_vpc_endpoint:
+            state: absent
+            vpc_endpoint_id: "{{ endpoint.vpc_endpoint_id }}"
+            region: "{{ infra__region }}"
+          loop: "{{ existing_endpoints.vpc_endpoints }}"
+          loop_control:
+            loop_var: endpoint
+            label: "{{ endpoint.vpc_endpoint_id }}"
+
+        - name: Wait for VPC Endpoint Deletion
+          community.aws.ec2_vpc_endpoint_info:
+            region: "{{ infra__region }}"
+            filters:
+              vpc-id: "{{ infra__aws_vpc_id }}"
+          register: existing_endpoints_wait
+          until: existing_endpoints_wait.vpc_endpoints | length == 0
+          retries: 15
+          delay: 10
+
         - name: Handle AWS Elastic Loadbalancers
           when:
             - __infra_ec2_elb_names is defined
@@ -174,6 +201,36 @@
             region: "{{ infra__region }}"
             route_table_id: "{{ __infra_aws_rtb_item.id }}"
             lookup: id
+            state: absent
+
+    - name: Teardown VPC Endpoints
+      when: infra__aws_private_endpoints | bool
+      block:
+        - name: Delete VPC Endpoints
+          community.aws.ec2_vpc_endpoint:
+            state: absent
+            vpc_endpoint_id: "{{ __infra_vpc_endpoint.vpc_endpoint_id }}"
+            region: "{{ infra__region }}"
+          loop: "{{ __infra_vpc_existing_endpoints.vpc_endpoints }}"
+          loop_control:
+            loop_var: __infra_vpc_endpoint
+            label: "{{ __infra_vpc_endpoint.vpc_endpoint_id }}"
+
+        - name: Wait for VPC Endpoint Deletion
+          community.aws.ec2_vpc_endpoint_info:
+            region: "{{ infra__region }}"
+            filters:
+              vpc-id: "{{ infra__aws_vpc_id }}"
+          register: __infra_existing_endpoints_wait
+          until: __infra_existing_endpoints_wait.vpc_endpoints | length == 0
+          retries: 15
+          delay: 10
+
+        - name: Delete VPC Endpoint Security Group
+          amazon.aws.ec2_group:
+            region: "{{ infra__region }}"
+            vpc_id: "{{ infra__aws_vpc_id }}"
+            name: "{{ infra__security_group_vpce_name }}"
             state: absent
 
     - name: Remove AWS Private Network

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -47,3 +47,17 @@ infra__dynamic_inventory_images_default:
 infra__all_ports_security_rule:
   aws: -1
   azure: 0-65535
+
+infra__aws_gateway_vpc_private_endpoints: 
+  - 'com.amazonaws.{{infra__region}}.s3'
+
+infra__aws_interface_vpc_private_endpoints:
+  - 'com.amazonaws.{{infra__region}}.elasticfilesystem'
+  - 'com.amazonaws.{{infra__region}}.ecr.dkr'
+  - 'com.amazonaws.{{infra__region}}.rds'
+  - 'com.amazonaws.{{infra__region}}.ecr.api'
+  - 'com.amazonaws.{{infra__region}}.sts'
+  - 'com.amazonaws.{{infra__region}}.ec2'
+  - 'com.amazonaws.{{infra__region}}.cloudformation'
+  - 'com.amazonaws.{{infra__region}}.elasticloadbalancing'
+  - 'com.amazonaws.{{infra__region}}.autoscaling'


### PR DESCRIPTION
cloudera.exe changes ONLY - No impact on cloudera.cloud and cdpy

This PR will:

- Create VPC Endpoints (and prereqs, like a Security Group) for the endpoints that CDP will use
- Runtime level doesn't need to "know" about these endpoints - It will just use them
- This will default to use the value of "tunnel". It can be overridden in your definition file
- Includes setup/teardown as well as abstracting the endpoints into a defaults file