### PR TITLE
Add GCP support to FreeIPA host group role

### DIFF
--- a/roles/freeipa_host_group/defaults/main.yml
+++ b/roles/freeipa_host_group/defaults/main.yml
@@ -23,5 +23,7 @@ freeipa_host_group__env_name:  "{{ common__env_name }}"
 freeipa_host_group__infra_type:  "{{ common__infra_type }}"
 freeipa_host_group__region:    "{{ common__region }}"
 
+freeipa_host_group__gcp_project: "{{ common__gcp_project }}"
+
 # Outputs
 freeipa_host_group__host_group_name: "freeipa_server_hosts"

--- a/roles/freeipa_host_group/tasks/main.yml
+++ b/roles/freeipa_host_group/tasks/main.yml
@@ -46,11 +46,22 @@
 #   when: freeipa_host_group__infra_type == "azure"
 #   block:
 
-# TODO: A block per cloud provider - GCP
 # Get instance details for specific infra_type - GCP
-# - name: Gather FreeIPA instance details on GCP
-#   when: freeipa_host_group__infra_type == "gcp"
-#   block:
+- name: Gather FreeIPA instance details on GCP
+  when: freeipa_host_group__infra_type == "gcp"
+  block:
+    - name: Gather Address information used by FreeIPA GCP instance
+      google.cloud.gcp_compute_address_info:
+        region: "{{ freeipa_host_group__region }}"
+        project: "{{ freeipa_host_group__gcp_project }}"
+        # Filter on the freeipa instance name with the timestamp stripped
+        filters:
+        - "name : {{ __freeipa_server_instance_id | regex_replace('[^-]+$', '') }}*"
+      register: __gcp_freeipa_address_info
+
+    - name: Set facts for the FreeIPA server IP
+      ansible.builtin.set_fact:
+        __freeipa_server_public_ip: "{{ __gcp_freeipa_address_info.resources | map(attribute='address') }}"
 
 # Add the FreeIPA server and username to the inventory
 - name: Add FreeIPA servers to inventory


### PR DESCRIPTION
Updated the freeipa_host_group role. Added support to determine the public IP address for FreeIPA instances in GCP environments.

Used the `google.cloud.gcp_compute_address_info` module rather than `google.cloud.gcp_compute_instance_info` to find the IP address. Reason for this is gcp_compute_instance_info requires the zone parameter in which the instance is running.

Signed-off-by: Jim Enright <jenright@cloudera.com>