### PR TITLE
Update streams messaging default template

### DIFF
--- a/roles/runtime/templates/datahub_streams_messaging_light.j2
+++ b/roles/runtime/templates/datahub_streams_messaging_light.j2
@@ -17,6 +17,13 @@ template: Streams Messaging Light Duty
 instance_groups:
   - instanceGroupName: master
   - instanceGroupName: broker
+    nodeCount: 0
+    instanceGroupType: CORE
+    attachedVolumeConfiguration:
+      - volumeSize: 500
+        volumeCount: 4
+        volumeType: "{{ run__datahub_storage[run__infra_type].fast }}"
+  - instanceGroupName: core_broker
     nodeCount: 3
     instanceGroupType: CORE
     attachedVolumeConfiguration:


### PR DESCRIPTION
The latest release of Streams Messaging seems to require a `core_broker` instance group name to be defined.
I've updated the default template for Streams Messaging Light Duty to include this. I also found that the `broker` instance group was still required but I've set the nodeCount on this to 0.

Tested this on an AWS and GCP CDP deployment and confirmed that both setup and teardown work.

Signed-off-by: Jim Enright <jenright@cloudera.com>