### PR TITLE
Add Ubuntu 20.04 focal fossa as optional OS for dynamic inventory

### DIFF
--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -43,6 +43,11 @@ infra__dynamic_inventory_images_default:
       user: 'ubuntu'
       owners:
         - '099720109477'
+    focal:
+      search: 'ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server*'
+      user: 'ubuntu'
+      owners:
+        - '099720109477'
 
 infra__all_ports_security_rule:
   aws: -1


### PR DESCRIPTION
Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>