### PR TITLE
Fix bug with __infra_aws_storage_tags_list

### DIFF
--- a/roles/infrastructure/tasks/setup_aws_storage.yml
+++ b/roles/infrastructure/tasks/setup_aws_storage.yml
@@ -52,7 +52,7 @@
   loop: "{{ infra__aws_storage_locations }}"
 
 - name: Update AWS Buckets tags (overwrite)
-  when: __infra_aws_storage_tags_list
+  when: __infra_aws_storage_tags_list is defined
   ansible.builtin.command: >
     aws s3api put-bucket-tagging
     --bucket {{ __infra_aws_storage_location_item.bucket }} 


### PR DESCRIPTION
Fix bug where no user tags are defined and therefore __infra_aws_storage_tags_list is undefined and blocks deployment

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>