### PR TITLE
region statement missing from modify-vpc-endpoint awscli call

### DIFF
--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -321,6 +321,7 @@
         - __aws_interface_vpc_endpoints.results is defined
       command: >
         aws ec2 modify-vpc-endpoint
+        --region {{ infra__region }}
         --vpc-endpoint-id {{ __infra_vpce_loop_var.result.vpc_endpoint_id }}
         --add-subnet-ids {{ infra__aws_public_subnet_ids | join(' ') }} 
         --add-security-group-ids {{ __aws_vpce_security_group_info.group_id }}


### PR DESCRIPTION
Should potentially be a hotfix deployments using this code path will fail with errors like "Region not set" if the user does not have a default region in their profile, or may fail with incorrect region specified if deployment region does not happen to match default region.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>