### PR TITLE
Support separate teardown for AWS utility vm

### DIFF
--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -36,6 +36,7 @@ infra__private_key_file:                 "{{ globals.ssh.private_key_file | defa
 infra__dynamic_inventory_count:          "{{ globals.dynamic_inventory.vm.count | default(0) }}"
 infra__dynamic_inventory_os:             "{{ globals.dynamic_inventory.vm.os | default('el7') }}"
 infra__dynamic_inventory_vm_suffix:      "{{ infra.dynamic_inventory.vm.suffix | default('vm') }}"
+infra__dynamic_inventory_utility_suffix: "{{ infra.dynamic_inventory.utility_vm.suffix | default('utility_vm') }}"
 infra__dynamic_inventory_vm_type:        "{{ infra.dynamic_inventory.vm.type | default('std') }}"
 infra__dynamic_inventory_storage_type:   "{{ infra.dynamic_inventory.storage.type | default('std') }}"
 infra__dynamic_inventory_storage_size:   "{{ infra.dynamic_inventory.storage.size | default('200') }}"
@@ -49,6 +50,7 @@ infra__teardown_deletes_data:       "{{ infra.teardown.delete_data | default(Fal
 infra__teardown_deletes_ssh_key:    "{{ infra.teardown.delete_ssh_key | default(False) }}"
 infra__teardown_deletes_network:    "{{ infra.teardown.delete_network | default(True) }}"
 infra__teardown_download_mirror:    "{{ infra.teardown.delete_mirror | default(False) }}"
+infra__teardown_utility_vm:         "{{ infra.teardown.delete_utility_vm | default(True) }}"
 
 infra__region:                      "{{ common__region }}"
 

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -174,11 +174,7 @@
   vars:
     __filters:
       - key: "tag:Name"
-        value: "{{ infra__namespace }}*"
-
-- name: Set fact for discovered EC2 Compute inventory
-  ansible.builtin.set_fact:
-    infra__discovered_compute_inventory: "{{ __infra_dynamic_inventory_discovered.instances + __infra_utility_compute_discovered.instances }}"
+        value: "{{ '-'.join([infra__namespace, infra__region, infra__dynamic_inventory_utility_suffix ]) }}"
 
 # Note that the download mirror is localised to the Account and Region deliberately
 - name: Determine Download Mirror Bucket Name

--- a/roles/infrastructure/tasks/initialize_teardown_aws.yml
+++ b/roles/infrastructure/tasks/initialize_teardown_aws.yml
@@ -47,10 +47,6 @@
           - key: "vpc-id"
             value: "{{ infra__aws_vpc_id }}"
 
-    - name: Update fact for discovered EC2 Compute inventory
-      ansible.builtin.set_fact:
-        infra__discovered_compute_inventory: "{{ infra__discovered_compute_inventory + __infra_vpc_ec2_instances.instances }}"
-
     - name: List AWS EKS clusters
       register: __infra_eks_cluster_list
       command: "aws eks list-clusters --region {{ infra__region }}"

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -67,10 +67,10 @@
         volume_size: 100
         delete_on_termination: yes
     wait: yes
-    instance_tags: "{{ infra__dynamic_inventory_tags | combine( {'Name': '-'.join([infra__namespace, infra__region, 'utility_vm' ]) }) }}"
+    instance_tags: "{{ infra__dynamic_inventory_tags | combine( {'Name': '-'.join([infra__namespace, infra__region, infra__dynamic_inventory_utility_suffix ]) }) }}"
     exact_count: 1
     count_tag:
-      Name: "{{ '-'.join([infra__namespace, infra__region, 'utility_vm' ]) }}"
+      Name: "{{ '-'.join([infra__namespace, infra__region, infra__dynamic_inventory_utility_suffix ]) }}"
     vpc_subnet_id: "{{ infra__aws_subnet_ids | first }}"
     assign_public_ip: yes
 

--- a/roles/infrastructure/tasks/teardown_aws_compute.yml
+++ b/roles/infrastructure/tasks/teardown_aws_compute.yml
@@ -104,10 +104,36 @@
   retries: 360
   delay: 10
 
-- name: Handle Compute Removal if Discovered
-  when: infra__discovered_compute_inventory | count > 0
+- name: Handle Dynamic Inventory Compute Removal if Discovered
+  when:
+    - __infra_dynamic_inventory_discovered is defined
+    - __infra_dynamic_inventory_discovered.instances is defined
+    - __infra_dynamic_inventory_discovered.instances | count > 0
   amazon.aws.ec2:
     region: "{{ infra__region }}"
     wait: yes
     state: absent
-    instance_ids: "{{ infra__discovered_compute_inventory | community.general.json_query('[*].instance_id') | list | unique }}"
+    instance_ids: "{{ __infra_dynamic_inventory_discovered.instances | community.general.json_query('[*].instance_id') | list | unique }}"
+
+- name: Handle Utility VM Compute Removal if Discovered
+  when:
+    - __infra_utility_compute_discovered is defined
+    - __infra_utility_compute_discovered.instances is defined
+    - __infra_utility_compute_discovered.instances | count > 0
+    - infra__teardown_utility_vm | bool
+  amazon.aws.ec2:
+    region: "{{ infra__region }}"
+    wait: yes
+    state: absent
+    instance_ids: "{{ __infra_utility_compute_discovered.instances | community.general.json_query('[*].instance_id') | list | unique }}"
+
+- name: Handle VPC Compute Removal if Discovered
+  when:
+    - __infra_vpc_ec2_instances is defined
+    - __infra_vpc_ec2_instances.instances is defined
+    - __infra_vpc_ec2_instances.instances | count > 0
+  amazon.aws.ec2:
+    region: "{{ infra__region }}"
+    wait: yes
+    state: absent
+    instance_ids: "{{ __infra_vpc_ec2_instances.instances | community.general.json_query('[*].instance_id') | list | unique }}"


### PR DESCRIPTION
Introduce definition option infra.teardown.delete_utility_vm which defaults to True to match current behavior OOTB
Move suffix of utility vm from hardcoded string to infra.dynamic_inventory.utility_vm.suffix
Rework AWS compute teardown to separately treat dynamic inventory, utility vm, and any compute for purging

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>