### PR TITLE
Fix globals for aws

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -58,6 +58,8 @@ common__unique_storage_name_suffix:       "{{ globals.storage.name | default((co
 
 # Infra
 common__infra_type:                       "{{ globals.infra_type | default('aws') }}"
+common__aws_region:                       "{{ globals.region | default('eu-west-1') }}"
+common__aws_profile:                      "{{ globals.profile | default('') }}"
 common__public_key_file:                  "{{ globals.ssh.public_key_file | default('') }}"
 common__namespace_cdp:                    "{{ globals.namespace_cdp | default([common__namespace, common__namespace_unique_suffix] | join('-')) }}"
 common__tags:                             "{{ globals.tags | default({}) }}"
@@ -90,8 +92,6 @@ common__ranger_audit_path:                "{{ infra.storage.path.ranger_audit | 
 common__aws_vpc_id:                       "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
 common__aws_public_subnet_ids:            "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
 common__aws_private_subnet_ids:           "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
-common__aws_region:                       "{{ infra.aws.region | default('eu-west-1') }}"
-common__aws_profile:                      "{{ infra.aws.profile | default('') }}"
 common__aws_role_suffix:                  "{{ infra.aws.role.suffix | default(common__role_suffix) }}"
 common__aws_datalake_admin_role_name:     "{{ env.aws.role.name.datalake_admin | default([common__namespace, common__aws_datalake_admin_suffix, common__aws_role_suffix] | join('-')) }}"
 common__aws_datalake_admin_suffix:        "{{ env.aws.role.label.datalake_admin | default(common__datalake_admin_suffix) }}"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -58,8 +58,7 @@ common__unique_storage_name_suffix:       "{{ globals.storage.name | default((co
 
 # Infra
 common__infra_type:                       "{{ globals.infra_type | default('aws') }}"
-common__aws_region:                       "{{ globals.region | default('eu-west-1') }}"
-common__aws_profile:                      "{{ globals.profile | default('') }}"
+common__aws_profile:                      "{{ globals.aws_profile | default('') }}"
 common__public_key_file:                  "{{ globals.ssh.public_key_file | default('') }}"
 common__namespace_cdp:                    "{{ globals.namespace_cdp | default([common__namespace, common__namespace_unique_suffix] | join('-')) }}"
 common__tags:                             "{{ globals.tags | default({}) }}"
@@ -89,6 +88,7 @@ common__data_path:                        "{{ infra.storage.path.data | default(
 common__ranger_audit_path:                "{{ infra.storage.path.ranger_audit | default('ranger/audit') }}"
 
 # AWS Infra
+common__aws_region:                       "{{ infra.aws.region | default('eu-west-1') }}"
 common__aws_vpc_id:                       "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
 common__aws_public_subnet_ids:            "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
 common__aws_private_subnet_ids:           "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"


### PR DESCRIPTION
AWS region is the default region for AWS, and now moved to top of the AWS specific section
AWS profile is a globals option and moved into the globals section

Note that common__aws_region is the default region for AWS deployments, similar to common__azure_region and common__gcp_region