### PR TITLE
Fix default Azure Netapp volume size

### DIFF
--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -133,7 +133,7 @@ infra__azure_netapp_account_name:   "{{ common__azure_netapp_account_name }}"
 infra__azure_netapp_pool_name:      "{{ common__azure_netapp_pool_name }}"
 infra__azure_netapp_vol_name:       "{{ common__azure_netapp_vol_name }}"
 
-infra__azure_netapp_pool_size:      "{{ infra.azure.netapp.pool.size | default(4) }}"
+infra__azure_netapp_pool_size:      "{{ infra.azure.netapp.pool.size | default(1) }}" # 4TB 'chunks'
 infra__azure_netapp_pool_type:      "{{ infra.azure.netapp.pool.type | default('Standard') }}"
 infra__azure_netapp_vol_size:       "{{ infra.azure.netapp.volume.size | default(500) }}"
 infra__azure_netapp_vol_type:       "{{ infra.azure.netapp.volume.type | default('Standard') }}"

--- a/roles/infrastructure/tasks/setup_azure_storage.yml
+++ b/roles/infrastructure/tasks/setup_azure_storage.yml
@@ -91,7 +91,7 @@
         name: "{{ infra__azure_netapp_pool_name }}"
         state: present
         location: "{{ infra__region }}"
-        size: "{{ infra__azure_netapp_pool_size }}"
+        size: "{{ infra__azure_netapp_pool_size | int }}"
         service_level: "{{ infra__azure_netapp_pool_type }}"
 
     - name: Handle Azure NetApp Volume


### PR DESCRIPTION
Update to reflect 'chunks' used by underlying module

Signed-off-by: Webster Mudge <wmudge@cloudera.com>