### PR TITLE
Support AWSCLI v2

### DIFF
--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -21,7 +21,7 @@
   loop_control:
     loop_var: __infra_compute_instance_item
   loop: "{{ range(0, infra__dynamic_inventory_count | int ) | list }}"
-  amazon.aws.ec2:
+  amazon.aws.ec2_instance:
     region: "{{ infra__region }}"
     group_id: "{{ infra__aws_security_group_default_id }}"
     key_name: "{{ infra__public_key_id }}"
@@ -53,7 +53,7 @@
 - name: Create localised Utility Instance to process Downloads
   when: infra__create_utility_service
   register: __infra_utility_vm_instance
-  amazon.aws.ec2:
+  amazon.aws.ec2_instance:
     region: "{{ infra__region }}"
     group_id: "{{ infra__aws_security_group_default_id }}"
     key_name: "{{ infra__public_key_id }}"

--- a/roles/infrastructure/tasks/teardown_aws_compute.yml
+++ b/roles/infrastructure/tasks/teardown_aws_compute.yml
@@ -106,7 +106,7 @@
 
 - name: Handle Compute Removal if Discovered
   when: infra__discovered_compute_inventory | count > 0
-  amazon.aws.ec2:
+  amazon.aws.ec2_instance:
     region: "{{ infra__region }}"
     wait: yes
     state: absent


### PR DESCRIPTION
Use amazon.aws.ec2_instance in place of amazon.aws.ec2 as it supports role delegated access

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>