### PR TITLE
Hotfix for Issue #83

### DIFF
--- a/roles/infrastructure/tasks/initialize_teardown_aws.yml
+++ b/roles/infrastructure/tasks/initialize_teardown_aws.yml
@@ -109,7 +109,7 @@
         label: "{{ __infra_asg_filter_item.auto_scaling_group_name }}"
 
     - name: List all AWS Elastic Loadbalancers
-      community.aws.ec2_elb_info:
+      community.aws.elb_classic_lb_info:
         region: "{{ infra__region }}"
       register: __infra_ec2_elbs
 

--- a/roles/infrastructure/tasks/teardown_aws_compute.yml
+++ b/roles/infrastructure/tasks/teardown_aws_compute.yml
@@ -60,7 +60,7 @@
     - infra__force_teardown | bool
     - __infra_aws_rds_instances is defined
     - __infra_aws_rds_instances | length > 0
-  community.aws.rds:
+  community.aws.rds_instance:
     command: delete
     region: "{{ infra__region }}"
     instance_name: "{{ __infra_rds_remove_item.db_instance_identifier }}"


### PR DESCRIPTION
Replace deprecated community.aws.ec2_elb_info with community.aws.elb_classic_lb_info
Replace deprecated community.aws.rds with community.aws.rds_instance

Fixes #83

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>