### PR TITLE
Support the use of other CDP control planes

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -56,6 +56,9 @@ common__ngw_suffix:                       "{{ globals.labels.nat_gateway | defau
 
 common__unique_storage_name_suffix:       "{{ globals.storage.name | default((common__region + common__aws_profile) if 'aws' in common__infra_type else common__region) }}"
 
+# CDP Control Plane Region
+common__cdp_control_plane_region:         "{{ globals.cdp_region | default('us-west-1') }}"
+common__cdp_control_plane_crn:            "{{ common__cdp_control_planes[common__cdp_control_plane_region] }}"
 # Infra
 common__infra_deployment_engine:          "{{ globals.infra_deployment_engine | default('ansible') }}"
 common__infra_type:                       "{{ globals.infra_type | default('aws') }}"

--- a/roles/common/vars/main.yml
+++ b/roles/common/vars/main.yml
@@ -18,3 +18,9 @@ common__region_default:
   aws: "{{ common__aws_region }}"
   azure: "{{ common__azure_region }}"
   gcp: "{{ common__gcp_region }}"
+
+common__cdp_control_planes:
+  us-west-1:  "crn:altus:iam:us-west-1:altus"
+  eu-1:       "crn:altus:iam:eu-1:altus"
+  ap-1:       "crn:altus:iam:ap-1:altus"
+  

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -40,6 +40,7 @@ plat__env_suffix:                             "{{ common__env_suffix }}"
 plat__vpc_private_subnets_suffix:             "{{ common__vpc_private_subnets_suffix }}"
 plat__vpc_public_subnets_suffix:              "{{ common__vpc_public_subnets_suffix }}"
 
+plat__cdp_control_plane_crn:                  "{{ common__cdp_control_plane_crn }}"
 plat__cdp_iam_role_suffix:                    "{{ plat__cdp_iam_identities.role_suffix }}"
 plat__cdp_iam_resource_suffix:                "{{ plat__cdp_iam_identities.resource_role_suffix }}"
 

--- a/roles/platform/tasks/initialize_setup_base.yml
+++ b/roles/platform/tasks/initialize_setup_base.yml
@@ -55,7 +55,7 @@
   ansible.builtin.set_fact:
     plat__cdp_pub_admin_group_role_crns: "{{ plat__cdp_pub_admin_group_role_crns | default([]) | union([role]) }}"
   vars:
-    role: "{{ [plat__cdp_iam_identities.namespace, plat__cdp_iam_role_suffix, __cdp_pub_admin_group_role_item] | join(':') }}"
+    role: "{{ [plat__cdp_control_plane_crn, plat__cdp_iam_role_suffix, __cdp_pub_admin_group_role_item] | join(':') }}"
   loop_control:
     loop_var: __cdp_pub_admin_group_role_item
   loop: "{{ plat__cdp_iam_admin_group_roles }}"
@@ -64,7 +64,7 @@
   ansible.builtin.set_fact:
     plat__cdp_pub_admin_group_resource_role_crns: "{{ plat__cdp_pub_admin_group_resource_role_crns | default([]) | union([resource_role]) }}"
   vars:
-    resource_role: "{{ [plat__cdp_iam_identities.namespace, plat__cdp_iam_resource_suffix, __cdp_env_admin_group_resource_role_item] | join(':') }}"
+    resource_role: "{{ [plat__cdp_control_plane_crn, plat__cdp_iam_resource_suffix, __cdp_env_admin_group_resource_role_item] | join(':') }}"
   loop_control:
     loop_var: __cdp_env_admin_group_resource_role_item
   loop: "{{ plat__cdp_iam_admin_group_resource_roles }}"
@@ -73,7 +73,7 @@
   ansible.builtin.set_fact:
     plat__cdp_pub_user_group_role_crns: "{{ plat__cdp_pub_user_group_role_crns | default([]) | union([role]) }}"
   vars:
-    role: "{{ [plat__cdp_iam_identities.namespace, plat__cdp_iam_role_suffix, __cdp_pub_user_group_role_item] | join(':') }}"
+    role: "{{ [plat__cdp_control_plane_crn, plat__cdp_iam_role_suffix, __cdp_pub_user_group_role_item] | join(':') }}"
   loop_control:
     loop_var: __cdp_pub_user_group_role_item
   loop: "{{ plat__cdp_iam_user_group_roles }}"
@@ -82,7 +82,7 @@
   ansible.builtin.set_fact:
     plat__cdp_pub_user_group_resource_role_crns: "{{ plat__cdp_pub_user_group_resource_role_crns | default([]) | union([resource_role]) }}"
   vars:
-    resource_role: "{{ [plat__cdp_iam_identities.namespace, plat__cdp_iam_resource_suffix, __cdp_pub_user_group_resource_role_item] | join(':') }}"
+    resource_role: "{{ [plat__cdp_control_plane_crn, plat__cdp_iam_resource_suffix, __cdp_pub_user_group_resource_role_item] | join(':') }}"
   loop_control:
     loop_var: __cdp_pub_user_group_resource_role_item
   loop: "{{ plat__cdp_iam_user_group_resource_roles }}"

--- a/roles/platform/vars/main.yml
+++ b/roles/platform/vars/main.yml
@@ -30,7 +30,6 @@ plat__gcp_roles:
   iam_service_account_token_creator: roles/iam.serviceAccountTokenCreator
 
 plat__cdp_iam_identities:
-  namespace: "crn:altus:iam:us-west-1:altus"
   role_suffix: role
   resource_role_suffix: resourceRole
   env_admin: EnvironmentAdmin


### PR DESCRIPTION
Fixes #90 

To support the use of different CDP Control Planes:
* In common, added CDP a map for control plane regions details to common and variables for the requested CDP region and its corresponding CRN.
* Updated the platform role to use the region variable when creating CDP IAM Groups.