### PR TITLE
Rearrange teardown tasks for GCP

### DIFF
--- a/roles/platform/tasks/teardown_gcp_authz.yml
+++ b/roles/platform/tasks/teardown_gcp_authz.yml
@@ -51,20 +51,6 @@
     project: "{{ plat__gcp_project }}"
     state: absent
 
-- name: Tear down Operational GCP Service Accounts
-  when: plat__teardown_deletes_roles
-  loop_control:
-    loop_var: __gcp_identity_item
-  loop:
-    - "{{ plat__gcp_log_identity_name }}"
-    - "{{ plat__gcp_datalakeadmin_identity_name }}"
-    - "{{ plat__gcp_ranger_audit_identity_name }}"
-    - "{{ plat__gcp_idbroker_identity_name }}"
-  google.cloud.gcp_iam_service_account:
-    name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    project: "{{ plat__gcp_project }}"
-    state: absent
-
 - name: Tear down Operational GCP Service Accounts Policies
   when: plat__teardown_deletes_policies
   register: __gcp_service_account_teardown
@@ -119,3 +105,17 @@
     gsutil iam
     ch -d {{ __gcp_pol_item.account |quote }}
     gs://{{ __gcp_pol_item.bucket |quote }}
+
+- name: Tear down Operational GCP Service Accounts
+  when: plat__teardown_deletes_roles
+  loop_control:
+    loop_var: __gcp_identity_item
+  loop:
+    - "{{ plat__gcp_log_identity_name }}"
+    - "{{ plat__gcp_datalakeadmin_identity_name }}"
+    - "{{ plat__gcp_ranger_audit_identity_name }}"
+    - "{{ plat__gcp_idbroker_identity_name }}"
+  google.cloud.gcp_iam_service_account:
+    name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+    project: "{{ plat__gcp_project }}"
+    state: absent

--- a/roles/platform/vars/main.yml
+++ b/roles/platform/vars/main.yml
@@ -26,7 +26,7 @@ plat__gcp_roles:
   storage_admin: roles/storage.admin
   storage_object_admin: roles/storage.objectAdmin
   iam_workload_identity_user: roles/iam.workloadIdentityUser
-  iam_service_account_user: roles/iam.workloadIdentityUser
+  iam_service_account_user: roles/iam.serviceAccountUser
   iam_service_account_token_creator: roles/iam.serviceAccountTokenCreator
 
 plat__cdp_iam_identities:


### PR DESCRIPTION
Fixes #92 

* Re-arranged GCP authz teardown tasks so that iam-policy-bindings are removed before the associated service accounts are deleted.
* Fixed a small typo in the value of the `plat__gcp_roles.iam_service_account_user` variable to point to the correct role.
* Tested to confirm that the GCP environment is successfully deleted with these changes.

Signed-off-by: Jim Enright <jenright@cloudera.com>