### PR TITLE
fix ec2 dynamic inventory and el8 deployment

### DIFF
--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -23,29 +23,30 @@
   loop: "{{ range(0, infra__dynamic_inventory_count | int ) | list }}"
   amazon.aws.ec2_instance:
     region: "{{ infra__region }}"
-    group_id: "{{ infra__aws_security_group_default_id }}"
+    security_group: "{{ infra__aws_security_group_default_id }}"
     key_name: "{{ infra__public_key_id }}"
     instance_type: "{{ infra__dynamic_inventory_vm_type_default[infra__type][infra__dynamic_inventory_vm_type] }}"
-    image: "{{ __infra_aws_ami_info.image_id }}"
+    image_id: "{{ __infra_aws_ami_info.image_id }}"
     ebs_optimized: yes
     volumes:
       - device_name: /dev/sda1
-        volume_type: "{{ infra__dynamic_inventory_storage_type_default[infra__type][infra__dynamic_inventory_storage_type] }}"
-        volume_size: "{{ infra__dynamic_inventory_storage_size }}"
-        delete_on_termination: "{{ infra__dynamic_inventory_delete_storage }}"
+        ebs:
+          volume_type: "{{ infra__dynamic_inventory_storage_type_default[infra__type][infra__dynamic_inventory_storage_type] }}"
+          volume_size: "{{ infra__dynamic_inventory_storage_size }}"
+          delete_on_termination: "{{ infra__dynamic_inventory_delete_storage | bool }}"
     wait: yes
-    instance_tags: "{{ infra__dynamic_inventory_tags | combine( {'Name': '-'.join([infra__namespace, infra__dynamic_inventory_vm_suffix, infra__dynamic_inventory_os[::2], '%02d' | format(__infra_compute_instance_item)]) }) }}"
-    exact_count: 1
-    count_tag:
-      Name: "{{ '-'.join([infra__namespace, infra__dynamic_inventory_vm_suffix, infra__dynamic_inventory_os[::2], '%02d' | format(__infra_compute_instance_item)]) }}"
+    state: running
+    tags: "{{ infra__dynamic_inventory_tags }}"
+    name: "{{ '-'.join([infra__namespace, infra__dynamic_inventory_vm_suffix, infra__dynamic_inventory_os[::2], '%02d' | format(__infra_compute_instance_item)]) }}"
     vpc_subnet_id: "{{ infra__aws_subnet_ids | first }}"
-    assign_public_ip: yes
+    network:
+      assign_public_ip: yes
 
 - name: Create output Dictionary for producing Static Inventory artefact
   ansible.builtin.set_fact:
     infra__dynamic_inventory_host_entries: "{{ infra__dynamic_inventory_host_entries | default([]) | union([host_entry]) }}"
   vars:
-    host_entry: "{{ [__infra_di_item.tagged_instances[0].private_dns_name, 'ansible_host=' + __infra_di_item.tagged_instances[0].public_ip, infra__dynamic_inventory_connectors] | join(' ') }}"
+    host_entry: "{{ [__infra_di_item.instances[0].private_dns_name, 'ansible_host=' + __infra_di_item.instances[0].public_ip_address, infra__dynamic_inventory_connectors] | join(' ') }}"
   loop: "{{ __infra_dynamic_inventory_instances.results }}"
   loop_control:
     loop_var: __infra_di_item
@@ -58,26 +59,27 @@
     group_id: "{{ infra__aws_security_group_default_id }}"
     key_name: "{{ infra__public_key_id }}"
     instance_type: "{{ infra__dynamic_inventory_vm_type_default[infra__type]['sml'] }}"
-    image: "{{ __infra_aws_ami_info.image_id }}"
+    image_id: "{{ __infra_aws_ami_info.image_id }}"
     ebs_optimized: yes
     instance_profile_name: "{{ infra__download_mirror_role.iam_role.role_name }}"
     volumes:
       - device_name: /dev/sda1
-        volume_type: "{{ infra__dynamic_inventory_storage_type_default[infra__type]['std'] }}"
-        volume_size: 100
-        delete_on_termination: yes
+        ebs:
+          volume_type: "{{ infra__dynamic_inventory_storage_type_default[infra__type]['std'] }}"
+          volume_size: 100
+          delete_on_termination: true
     wait: yes
-    instance_tags: "{{ infra__dynamic_inventory_tags | combine( {'Name': '-'.join([infra__namespace, infra__region, 'utility_vm' ]) }) }}"
-    exact_count: 1
-    count_tag:
-      Name: "{{ '-'.join([infra__namespace, infra__region, 'utility_vm' ]) }}"
+    state: running
+    instance_tags: "{{ infra__dynamic_inventory_tags }}"
+    name: "{{ '-'.join([infra__namespace, infra__region, 'utility_vm' ]) }}"
     vpc_subnet_id: "{{ infra__aws_subnet_ids | first }}"
-    assign_public_ip: yes
+    network:
+      assign_public_ip: yes
 
 - name: Add Utility Instance to host group
   when: infra__create_utility_service
   ansible.builtin.add_host:
-    hostname: "{{__infra_utility_vm_instance.tagged_instances[0].public_ip}}"
+    hostname: "{{ __infra_utility_vm_instance.instances[0].public_ip_address }}"
     ansible_user: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os].user }}"
     ansible_ssh_private_key_file: "{{ (infra__private_key_file == '') | ternary(omit, infra__private_key_file) }}"
     groupname: cldr_utility

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -17,7 +17,6 @@
 # You must have subscribed to Centos in the AWS Marketplace: https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce
 
 - name: Ensure required number of Dynamic Inventory VMs are deployed and tagged correctly during deployment
-  register: __infra_dynamic_inventory_instances
   loop_control:
     loop_var: __infra_compute_instance_item
   loop: "{{ range(0, infra__dynamic_inventory_count | int ) | list }}"
@@ -42,12 +41,23 @@
     network:
       assign_public_ip: yes
 
+- name: Ensure instances have Public IPs assigned
+  register: __infra_dynamic_inventory_instances
+  amazon.aws.ec2_instance_info:
+    region: "{{ infra__region }}"
+    filters:
+      "tag:Name": "{{ infra__namespace }}-*"
+      instance-state-name: [ "running" ]
+  until: __infra_dynamic_inventory_instances.instances | selectattr('public_ip_address', 'defined') | list | count | int == infra__dynamic_inventory_count | int
+  retries: 5
+  delay: 5
+
 - name: Create output Dictionary for producing Static Inventory artefact
   ansible.builtin.set_fact:
     infra__dynamic_inventory_host_entries: "{{ infra__dynamic_inventory_host_entries | default([]) | union([host_entry]) }}"
   vars:
-    host_entry: "{{ [__infra_di_item.instances[0].private_dns_name, 'ansible_host=' + __infra_di_item.instances[0].public_ip_address, infra__dynamic_inventory_connectors] | join(' ') }}"
-  loop: "{{ __infra_dynamic_inventory_instances.results }}"
+    host_entry: "{{ [__infra_di_item.private_dns_name, 'ansible_host=' + __infra_di_item.public_ip_address, infra__dynamic_inventory_connectors] | join(' ') }}"
+  loop: "{{ __infra_dynamic_inventory_instances.instances }}"
   loop_control:
     loop_var: __infra_di_item
 

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -34,10 +34,10 @@ infra__dynamic_inventory_images_default:
       owners:
         - 'aws-marketplace'
     el8:
-      search: 'CentOS 8.2*x86*'
-      user: 'centos'
+      search: 'RHEL-8.4*HVM*x86_64*'
+      user: 'ec2-user'
       owners:
-        - '125523088429'
+        - '309956199498'
     bionic:
       search: 'ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server*'
       user: 'ubuntu'


### PR DESCRIPTION
Note that fixes in PR 81 on Cloudera Deploy make el8 behave correctly on older versions of Ansible (2.10) when working with newer OS (el8), but are not required for this PR unless you are in fact testing that particular combination.
https://github.com/cloudera-labs/cloudera-deploy/pull/81

Update AWS dynamic inventory to use amazon.aws.ec2_instance as the amazon.aws.ec2 was deprecated and settings are different
Replaced Centos8.2 with RHEL8.4, as Centos is very much dead at this point