### PR TITLE
CDW Round 47

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -30,6 +30,7 @@ datahub:
     gcp:
   suffix:
   tags:
+  force_delete:
 de:
   definitions:
   suffix:
@@ -82,7 +83,35 @@ df:
                   id: SECONDS|MINUTES|HOURS|DAYS
 dw:
   definitions:
+    - name:
+      use_default_dbc:
+      load_demo_data:
+      virtual_warehouses:
+        - name:
+          type:
+          template:
+          autoscaling:
+            min_nodes:
+            max_nodes:
+          tags:
+          configs:
+            common_configs:
+            application_configs:
+            enable_sso:
+            ldap_groups:
   suffix:
+  vw:
+    suffix:
+    type:
+    template:
+  dbc:
+    suffix:
+    default_suffix: 
+  tags:
+  overlay_network:
+  private_load_balancer:
+  private_worker_nodes:
+  force_delete:
 env:
   aws:
     arn_partition: aws | aws-cn | aws-us-gov (See https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
@@ -247,7 +276,7 @@ globals:
   dynamic_inventory:
     vm:
       count:
-      os:
+  force_teardown:
   gcloud_credential_file:
   infra_deployment_engine:
   infra_type:
@@ -411,6 +440,7 @@ ml:
   suffix:
   tags:
   public_loadbalancer:
+  force_delete:
 opdb:
   definitions:
   suffix:

--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -276,6 +276,7 @@ globals:
   dynamic_inventory:
     vm:
       count:
+      os:
   force_teardown:
   gcloud_credential_file:
   infra_deployment_engine:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -117,11 +117,6 @@ common__aws_datalake_admin_suffix:        "{{ env.aws.role.label.datalake_admin 
 common__aws_idbroker_role_name:           "{{ env.aws.role.name.idbroker | default([common__namespace, common__aws_idbroker_suffix, common__aws_role_suffix] | join('-')) }}"
 common__aws_idbroker_suffix:              "{{ env.aws.role.label.idbroker | default(common__idbroker_suffix) }}"
 
-
-common__aws_vpc_id:                       "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
-common__aws_public_subnet_ids:            "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
-common__aws_private_subnet_ids:           "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
-
 # Azure Infra
 common__azure_storage_name:               "{{ infra.azure.storage.name | default(common__storage_name | replace('-','')) }}"
 

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -111,10 +111,16 @@ common__aws_public_subnet_ids:            "{{ infra.aws.vpc.existing.public_subn
 common__aws_private_subnet_ids:           "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
 common__aws_region:                       "{{ infra.aws.region | default('eu-west-1') }}"
 common__aws_role_suffix:                  "{{ infra.aws.role.suffix | default(common__role_suffix) }}"
+
 common__aws_datalake_admin_role_name:     "{{ env.aws.role.name.datalake_admin | default([common__namespace, common__aws_datalake_admin_suffix, common__aws_role_suffix] | join('-')) }}"
 common__aws_datalake_admin_suffix:        "{{ env.aws.role.label.datalake_admin | default(common__datalake_admin_suffix) }}"
 common__aws_idbroker_role_name:           "{{ env.aws.role.name.idbroker | default([common__namespace, common__aws_idbroker_suffix, common__aws_role_suffix] | join('-')) }}"
 common__aws_idbroker_suffix:              "{{ env.aws.role.label.idbroker | default(common__idbroker_suffix) }}"
+
+
+common__aws_vpc_id:                       "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
+common__aws_public_subnet_ids:            "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
+common__aws_private_subnet_ids:           "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
 
 # Azure Infra
 common__azure_storage_name:               "{{ infra.azure.storage.name | default(common__storage_name | replace('-','')) }}"

--- a/roles/common/meta/main.yml
+++ b/roles/common/meta/main.yml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 galaxy_info:
+  role_name: platform
+  namespace: cloudera
   author: Webster Mudge (wmudge@cloudera.com)
   description: >
     Shared configuration variables managed by role dependency. 

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -95,9 +95,9 @@ infra__vpc_user_ports:              "{{ infra.vpc.user_ports | default([infra__a
 infra__vpc_user_cidr:               "{{ infra.vpc.user_cidr | default([]) }}"
 infra__vpc_tunneled_cidr:           "{{ infra.vpc.tunneled_cidr | default([]) }}"
 
-infra__aws_vpc_id:                  "{{ infra.aws.vpc.existing.vpc_id | default('') }}"
-infra__aws_public_subnet_ids:       "{{ infra.aws.vpc.existing.public_subnet_ids | default([]) }}"
-infra__aws_private_subnet_ids:      "{{ infra.aws.vpc.existing.private_subnet_ids | default([]) }}"
+infra__aws_vpc_id:                  "{{ common__aws_vpc_id }}"
+infra__aws_public_subnet_ids:       "{{ common__aws_public_subnet_ids }}"
+infra__aws_private_subnet_ids:      "{{ common__aws_private_subnet_ids }}"
 
 infra__security_group_knox_name:    "{{ common__security_group_knox_name }}"
 infra__security_group_default_name: "{{ common__security_group_default_name }}"

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -115,7 +115,6 @@
 
         - name: Set facts for existing AWS Public Subnet IDs
           ansible.builtin.set_fact:
-            infra__aws_public_subnet_ids: "{{ infra__aws_public_subnet_ids }}"
             infra__aws_subnet_ids: "{{ infra__aws_subnet_ids | default([]) | union(infra__aws_public_subnet_ids) }}"
             infra__aws_vpc_id: "{{ __aws_public_subnets_info.subnets | map(attribute='vpc_id') | list | first }}"
 

--- a/roles/infrastructure/tasks/setup.yml
+++ b/roles/infrastructure/tasks/setup.yml
@@ -33,7 +33,7 @@
     ansible.builtin.include_tasks: "setup_{{ infra__type | lower }}_utility_service.yml"
 
   - name: Set up provider-specific Infrastructure Compute
-    when: infra__dynamic_inventory_count
+    when: infra__dynamic_inventory_count | int > 0
     ansible.builtin.include_tasks: "setup_{{ infra__type | lower }}_compute.yml"
 
 - name: Set up for Terraform deployment engine

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -120,6 +120,9 @@ plat__aws_storage_suffix:                     "{{ env.aws.storage.suffix | defau
 plat__aws_role_tags:                          "{{ env.aws.role.tags | default({}) }}"
 plat__aws_policy_tags:                        "{{ env.aws.policy.tags | default({}) }}"
 plat__aws_storage_tags:                       "{{ env.aws.storage.tags | default({}) }}"
+plat__aws_vpc_id:                             "{{ common__aws_vpc_id }}"
+plat__aws_public_subnet_ids:                  "{{ common__aws_public_subnet_ids }}"
+plat__aws_private_subnet_ids:                 "{{ common__aws_private_subnet_ids }}"
 
 plat__aws_xaccount_suffix:                    "{{ env.aws.role.label.cross_account | default(common__xaccount_suffix) }}"
 plat__aws_idbroker_suffix:                    "{{ common__aws_idbroker_suffix }}"

--- a/roles/platform/meta/main.yml
+++ b/roles/platform/meta/main.yml
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 galaxy_info:
+  role_name: platform
+  namespace: cloudera
   author: Webster Mudge (wmudge@cloudera.com)
   description: >
     Deployment and management of Cloudera Data Platform (CDP) Public Cloud core

--- a/roles/platform/tasks/initialize_aws.yml
+++ b/roles/platform/tasks/initialize_aws.yml
@@ -18,3 +18,8 @@
   amazon.aws.aws_caller_info:
   register: __aws_caller_info
   failed_when: __aws_caller_info.account is not defined
+
+- name: Confirm AWS SSH Public Key ID exists
+  ansible.builtin.command: aws ec2 describe-key-pairs --region "{{ plat__region }}" --key-name "{{ plat__public_key_id }}"
+  register: __aws_ssh_key_pair
+  failed_when: __aws_ssh_key_pair.rc != 0

--- a/roles/platform/tasks/initialize_setup_aws.yml
+++ b/roles/platform/tasks/initialize_setup_aws.yml
@@ -49,7 +49,7 @@
     plat__aws_xaccount_account_id: "{{ plat__cdp_xaccount_account_id }}"
 
 # Runlevel first, upstream second, and discover third
-- name: Discover AWS VPC if not defined
+- name: Discover AWS VPC if not defined or established by Infrastructure
   when: plat__aws_vpc_id == "" and infra__aws_vpc_id is undefined
   block:
     - name: Query AWS VPC by name
@@ -71,13 +71,12 @@
         plat__aws_vpc_id: "{{ __aws_vpc_info.vpcs[0].id }}"
 
 - name: Set fact for AWS VPC ID if established by Infrastructure
-  when: infra__aws_vpc_id is defined
+  when: plat__aws_vpc_id == "" and infra__aws_vpc_id is defined
   ansible.builtin.set_fact:
     plat__aws_vpc_id: "{{ infra__aws_vpc_id }}"
 
-# Runlevel first, upstream second, and discover third
-- name: Handle AWS Public and Private VPC Subnets if not defined
-  when: not plat__aws_public_subnet_ids or not plat__aws_private_subnet_ids
+- name: Handle AWS Subnet IDs if not defined
+  when: not plat__aws_public_subnet_ids or not plat__aws_private_subnet_ids # Defaults are empty lists
   block:
     - name: Query AWS Subnets
       amazon.aws.ec2_vpc_subnet_info:
@@ -144,6 +143,7 @@
   ansible.builtin.set_fact:
     plat__endpoint_access_scheme: "PUBLIC"
 
+# TODO Collapse the two SG queries together
 - name: Discover AWS Security Group for Knox
   when: infra__aws_security_group_knox_id is undefined
   block:
@@ -151,6 +151,7 @@
       amazon.aws.ec2_group_info:
         region: "{{ plat__region }}"
         filters:
+          vpc-id: "{{ plat__aws_vpc_id }}"
           group-name: "{{ plat__security_group_knox_name }}"
       register: __aws_security_group_knox_info
 
@@ -171,6 +172,7 @@
       amazon.aws.ec2_group_info:
         region: "{{ plat__region }}"
         filters:
+          vpc-id: "{{ plat__aws_vpc_id }}"
           group-name: "{{ plat__security_group_default_name }}"
       register: __aws_security_group_default_info
 

--- a/roles/platform/tasks/setup_aws_env.yml
+++ b/roles/platform/tasks/setup_aws_env.yml
@@ -31,7 +31,7 @@
     subnet_ids: "{{ plat__aws_public_subnet_ids | union(plat__aws_private_subnet_ids) }}"
     tags: "{{ plat__tags }}"
     tunnel: "{{ plat__tunnel }}"
-    endpoint_access_scheme: "{{ plat__endpoint_access_scheme | default(omit) }}"
+    endpoint_access_scheme: "{{ plat__public_endpoint_access | ternary('PUBLIC', omit) }}"
     endpoint_access_subnets: "{{ plat__aws_public_subnet_ids | default(omit) }}"
     freeipa:
       instanceCountByGroup: "{{ plat__env_freeipa }}"

--- a/roles/runtime/defaults/main.yml
+++ b/roles/runtime/defaults/main.yml
@@ -71,8 +71,17 @@ run__de_force_delete:               "{{ de.force_delete | default (run__force_te
 run__de_vc_suffix:                  "{{ de.vc.suffix | default('vc') }}"
 
 run__dw_definitions:                "{{ dw.definitions | default([{}]) }}"
-run__dw_suffix:                     "{{ dw.suffix | default('dw') }}"
+run__dw_dbc_suffix:                 "{{ dw.dbc.suffix | default('dbc') }}"
+run__dw_vw_suffix:                  "{{ dw.vw.suffix | default('vw') }}"
+run__dw_tags:                       "{{ dw.tags | default(common__tags) }}"
+run__dw_overlay_network:            "{{ dw.overlay_network | default(False) | bool }}"
+run__dw_private_load_balancer:      "{{ dw.private_load_balancer | default(not run__public_endpoint_access) }}"
+run__dw_private_worker_nodes:       "{{ dw.private_worker_nodes | default(False) | bool }}"
 run__dw_force_delete:               "{{ dw.force_delete | default (run__force_teardown) }}"
+run__dw_default_vw_type:            "{{ dw.default_vw.type | default('hive') }}"
+run__dw_default_template_type:      "{{ dw.default_template.type | default('xsmall') }}"
+run__dw_default_dbc_suffix:         "{{ dw.default_dbc.suffix | default('dl-default') }}"
+run__dw_default_dbc:                "{{ dw.default_dbc.name | default([run__env_name, run__dw_default_dbc_suffix] | join('-')) }}"
 
 run__df_nodes_min:                  "{{ df.min_k8s_nodes | default(3) }}"
 run__df_nodes_max:                  "{{ df.max_k8s_nodes | default(5) }}"

--- a/roles/runtime/tasks/initialize_base.yml
+++ b/roles/runtime/tasks/initialize_base.yml
@@ -52,6 +52,7 @@
       ansible.builtin.set_fact:
         run__cdp_datalake_version: "{{ __cdp_datalake_version_info.versions[0].runtimeVersion | trim }}"
 
+# TODO Discover version if upstream is not present
 - name: Set fact for CDP Datalake version by assignment
   when: plat__cdp_datalake_version is defined
   ansible.builtin.set_fact:
@@ -64,7 +65,7 @@
     - name: Retrieve Image Catalog File
       ansible.builtin.uri:
         url: "{{ run__datahub_image_catalog_url }}"
-      #no_log: yes
+      no_log: yes
       register: __datahub_image_catalog
 
     - name: Set fact for latest CDP Image in Catalog
@@ -183,6 +184,59 @@
       loop_control:
         loop_var: __de_config
         label: "{{ config.name }}"
+
+
+- name: Prepare for CDP DW experiences
+  when: run__include_dw
+  block:
+    - name: Construct CDP DW Data Catalog configurations
+      ansible.builtin.set_fact:
+        run__dw_dbc_configs: "{{ run__dw_dbc_configs | default([]) | union([config]) }}"
+      vars:
+        include: "{{ lookup('template', __dw_config.include | default('experiences_config_placeholder.j2')) | from_yaml }}"
+        config:
+          name: "{{ __dw_config.name | default(run__dw_default_dbc) }}"
+          load_demo_data: "{{ __dw_config.load_demo_data | default(False) | bool }}"
+          virtual_warehouses: "{{ __dw_config.virtual_warehouses | default([]) }}"
+          use_default_dbc: "{{ __dw_config.use_default_dbc | default(True) | bool }}"
+      loop: "{{ run__dw_definitions }}"
+      loop_control:
+        loop_var: __dw_config
+        index_var: __dw_config_index
+
+    - name: Construct CDP DW Virtual Warehouse configurations
+      ansible.builtin.set_fact:
+        run__dw_vw_configs: "{{ run__dw_vw_configs | default([]) | union([config]) }}"
+      vars:
+        config:
+          dbc_name: "{{ __dw_config.0.name }}"
+          name: "{{ __dw_config.1.name | default([run__namespace, run__dw_vw_suffix ,__dw_dbc_index] | join('-')) }}"
+          use_default_dbc: "{{ __dw_config.0.use_default_dbc }}"
+          type: "{{ __dw_config.1.type | default(run__dw_default_vw_type) }}"
+          template: "{{ __dw_config.1.template | default(run__dw_default_template_type) }}"
+          tags: "{{ __dw_config.1.tags | default({}) | combine(run__dw_tags) }}"
+          autoscaling: "{{ __dw_config.1.autoscaling | default({}) }}"
+          configs: "{{ __dw_config.1.configs | default({}) }}"
+      loop: "{{ run__dw_dbc_configs | default({}) | subelements('virtual_warehouses')}}"
+      loop_control:
+        loop_var: __dw_config
+        index_var: __dw_dbc_index
+        label: "{{ config.name }}"
+
+    - name: Check CDP DW Virtual Warehouse tags
+      when: __dw_vw_config.tags | length > 0
+      ansible.builtin.assert:
+        that:
+          - __dw_vw_config.tags | dict2items | rejectattr('value', 'regex', '[^-_a-zA-Z0-9.=:+@]+') | list
+        fail_msg: 
+          - "A tag in Data Warehouse, '{{ __dw_vw_config.name }}', does not meet requirements;"
+          - "current tags: {{ __dw_vw_config.tags}}."
+          - "Allowed characters in tags are letters, numbers and the following characters: _.:/=+-@"
+        quiet: yes
+      loop_control:
+        loop_var: __dw_vw_config
+        label: "{{ __dw_vw_config.name }}"
+      loop: "{{ run__dw_vw_configs }}"
 
 - name: Prepare for CDP DF Service experiences
   tags: df

--- a/roles/runtime/tasks/initialize_setup.yml
+++ b/roles/runtime/tasks/initialize_setup.yml
@@ -31,3 +31,19 @@
     - dh
     - df
     - de
+
+- name: Prepare for CDP DW experiences
+  when: run__include_dw
+  block:
+    - name: Confirm public subnet count CDP DW public load balancer
+      when: not run__dw_private_load_balancer
+      ansible.builtin.assert:
+        that:
+          - run__public_subnet_ids | length == 3
+        fail_msg: "Must have exactly 3 public subnets when deploying CDP Data Warehouse with a public load balancer"
+        quiet: yes
+      tags:
+        - ml
+        - dw
+        - opdb
+        - dh

--- a/roles/runtime/tasks/initialize_teardown.yml
+++ b/roles/runtime/tasks/initialize_teardown.yml
@@ -30,16 +30,17 @@
     name: "{{ run__env_name }}"
   register: run__df_env_info
 
+- name: Discover CDP Data Warehouse cluster
+  cloudera.cloud.dw_cluster_info:
+    env: "{{ run__env_name }}"
+  register: __dw_list
+
 - name: Discover CDP Data Warehouse deployments
   when: 
     - run__include_dw
     - not run__force_teardown | bool or not run__dw_force_delete | bool
+    - __dw_list.clusters | length > 0
   block:
-    - name: Discover CDP Data Warehouse cluster
-      cloudera.cloud.dw_cluster_info:
-        env: "{{ run__env_name }}"
-      register: __dw_list
-
     - name: Initialize CDP Data Warehouse cluster id
       ansible.builtin.set_fact:
         __dw_cluster_id: "{{ __dw_list.clusters | map(attribute='id') | first | default(omit) }}"

--- a/roles/runtime/tasks/initialize_teardown.yml
+++ b/roles/runtime/tasks/initialize_teardown.yml
@@ -24,11 +24,37 @@
   when: not run__force_teardown
   ansible.builtin.include_tasks: "initialize_base.yml"
 
-- name: Discover CDP DF Deployments
-  register: run__df_service_info
+- name: Discover CDP Dataflow deployments
   when: run__include_df
   cloudera.cloud.df_service_info:
     name: "{{ run__env_name }}"
+  register: run__df_env_info
+
+- name: Discover CDP Data Warehouse deployments
+  when: 
+    - run__include_dw
+    - not run__force_teardown | bool or not run__dw_force_delete | bool
+  block:
+    - name: Discover CDP Data Warehouse cluster
+      cloudera.cloud.dw_cluster_info:
+        env: "{{ run__env_name }}"
+      register: __dw_list
+
+    - name: Initialize CDP Data Warehouse cluster id
+      ansible.builtin.set_fact:
+        __dw_cluster_id: "{{ __dw_list.clusters | map(attribute='id') | first | default(omit) }}"
+
+    - name: Discover CDP Data Warehouse database catalogs
+      when: __dw_cluster_id is defined
+      cloudera.cloud.dw_database_catalog_info:
+        cluster_id: "{{ __dw_cluster_id }}"
+      register: __dw_dbc_list
+
+    - name: Discover CDP Data Warehouse virtual warehouses
+      when: __dw_cluster_id is defined
+      cloudera.cloud.dw_virtual_warehouse_info:
+        cluster_id: "{{ __dw_cluster_id }}"
+      register: __dw_vw_list
 
 - name: Initialize Purge of all Runtimes in Environment
   when:

--- a/roles/runtime/tasks/setup_aws.yml
+++ b/roles/runtime/tasks/setup_aws.yml
@@ -35,31 +35,107 @@
         label: "{{ __aws_instance_item.instance_id }}"
       loop: "{{ __aws_instance_info.instances }}"
 
-- name: Setup CDP DW cluster on AWS
+- name: Setup CDP Data Warehouse on AWS
   when: run__include_dw
   tags: dw
   block:
-    - name: Execute CDP DW cluster setup
+    - name: Execute CDP Data Warehouse environment setup
       cloudera.cloud.dw_cluster:
         env: "{{ run__env_name }}"
-        overlay: no
-        # TODO - Allow direct assignment (will need to coordinate with infra role)
-        aws_public_subnets: "{{ run__public_subnet_ids }}"
-        aws_private_subnets: "{{ run__private_subnet_ids }}"
+        overlay: "{{ run__dw_overlay_network }}"
+        private_load_balancer: "{{ run__dw_private_load_balancer }}"
+        aws_public_subnets: "{{ run__aws_public_subnet_ids }}"
+        aws_private_subnets: "{{ run__aws_private_subnet_ids if run__dw_private_worker_nodes else [] }}"
+        state: present
+        wait: yes
+      register: __dw_cluster_build
+
+    - name: Set fact for DW Cluster
+      ansible.builtin.set_fact:
+        __dw_cluster_id: "{{ __dw_cluster_build.cluster.id }}"
+
+    - name: Fetch all the Database Catalogs under the cluster
+      cloudera.cloud.dw_database_catalog_info:
+        cluster_id: "{{ __dw_cluster_id }}"
+      register: __dbc_list
+
+    - name: Set default Database catalog id for the cluster
+      when: __dw_dbc.name | regex_search('.*'+run__dw_default_dbc_suffix+'$')
+      ansible.builtin.set_fact:
+        __default_dbc_id: "{{ __dw_dbc.id }}"
+      loop: "{{ __dbc_list.database_catalogs }}"
+      loop_control:
+        loop_var: __dw_dbc
+
+    - name: Create Additional CDP DW Database catalogs
+      when: not __dw_dbc_config.use_default_dbc
+      cloudera.cloud.dw_database_catalog:
+        cluster_id : "{{ __dw_cluster_id }}"
+        name: "{{ __dw_dbc_config.name }}"
+        load_demo_data: "{{ __dw_dbc_config.load_demo_data }}"
         state: present
         wait: yes
       async: 3600 # 1 hour timeout
       poll: 0
-      register: __dw_builds
+      loop: "{{ run__dw_dbc_configs }}"
+      loop_control:
+        loop_var: __dw_dbc_config
+        label: "{{ __dw_dbc_config.name }}"
+      register: __dw_dbc_builds
 
-    - name: Wait for CDP DW cluster setup to complete
+    - name: Wait for additional CDP DW Database catalogs setup to complete
+      when: __dw_dbc_build.ansible_job_id is defined
       ansible.builtin.async_status:
-        jid: "{{ __dw_builds.ansible_job_id }}"
-      #loop_control:
-      #  loop_var: __opdb_build
-      #  label: "{{ __opdb_build.__opdb_config.name }}"
-      #loop: "{{ __opdb_builds.results }}"
-      register: __dw_builds_async
-      until: __dw_builds_async.finished
+        jid: "{{ __dw_dbc_build.ansible_job_id }}"
+      register: __dw_dbc_builds_async
+      until: __dw_dbc_builds_async.finished
       retries: 120
       delay: 30
+      loop: "{{ __dw_dbc_builds.results }}"
+      loop_control:
+        loop_var: __dw_dbc_build
+        label: "{{ __dw_dbc_build.__dw_dbc_config.name }}"
+
+    - name: Set CDP DW Database catalog name to id map
+      when: __dw_dbc_build_async.database_catalog is defined
+      ansible.builtin.set_fact:
+        run__dw_dbc_ids: "{{ run__dw_dbc_ids | default({}) | combine({ __dw_dbc_build_async.database_catalog.name : __dw_dbc_build_async.database_catalog.id}) }}"
+      loop: "{{ __dw_dbc_builds_async.results }}"
+      loop_control:
+        loop_var: __dw_dbc_build_async
+
+    - name: Create CDP DW Virtual warehouses
+      cloudera.cloud.dw_virtual_warehouse:
+        cluster_id: "{{ __dw_cluster_id }}"
+        dbc_id: "{{ __dw_vw_config.use_default_dbc | ternary(__default_dbc_id, run__dw_dbc_ids[__dw_vw_config.dbc_name]) }}"
+        type: "{{ __dw_vw_config.type }}"
+        name: "{{ __dw_vw_config.name }}"
+        template: "{{ __dw_vw_config.template }}"
+        tags: "{{ __dw_vw_config.tags }}"
+        autoscaling_min_nodes: "{{ __dw_vw_config.autoscaling.min_nodes | default(omit) }}"
+        autoscaling_max_nodes: "{{ __dw_vw_config.autoscaling.max_nodes | default(omit) }}"
+        common_configs: "{{ __dw_vw_config.configs.common_configs | default(omit) }}"
+        application_configs: "{{ __dw_vw_config.configs.application_configs | default(omit) }}"
+        ldap_groups: "{{ __dw_vw_config.configs.ldap_groups | default(omit) }}"
+        enable_sso: "{{ __dw_vw_config.configs.enable_sso | default(omit) }}"
+        wait: yes
+      async: 3600 # 1 hour timeout
+      poll: 0
+      register: __dw_vw_builds
+      loop: "{{ run__dw_vw_configs }}"
+      loop_control:
+        pause: 30 #Avoid dual compactors
+        loop_var: __dw_vw_config
+        label: "{{ __dw_vw_config.name }}"
+
+    - name: Wait for CDP DW Virtual warehouses setup to complete
+      ansible.builtin.async_status:
+        jid: "{{ __dw_vw_build.ansible_job_id }}"
+      register: __dw_vw_builds_async
+      until: __dw_vw_builds_async.finished
+      retries: 120
+      delay: 30
+      loop: "{{ __dw_vw_builds.results }}"
+      loop_control:
+        loop_var: __dw_vw_build
+        label: "{{ __dw_vw_build.__dw_vw_config.name }}"

--- a/roles/runtime/tasks/setup_base.yml
+++ b/roles/runtime/tasks/setup_base.yml
@@ -111,7 +111,7 @@
   when: run__include_df
   tags: df
   cloudera.cloud.df_service:
-    env_crn: "{{ run__cdp_env_crn }}"
+    name: "{{ run__cdp_env_crn }}"
     nodes_min: "{{ run__df_nodes_min }}"
     nodes_max: "{{ run__df_nodes_max }}"
     public_loadbalancer: "{{ run__df_public_loadbalancer }}"
@@ -184,7 +184,7 @@
   when: run__include_df
   tags: df
   cloudera.cloud.df_service:
-    env_crn: "{{ run__cdp_env_crn }}"
+    name: "{{ run__cdp_env_crn }}"
     wait: yes
 
 # Request Service child deployments

--- a/roles/runtime/tasks/teardown_base.yml
+++ b/roles/runtime/tasks/teardown_base.yml
@@ -32,26 +32,92 @@
   poll: 0
   register: __opdb_teardowns_info
 
-- name: Execute CDP DW cluster teardown
-  register: __dw_teardown_info
+- name: Execute CDP Data Warehouse virtual warehouse teardown
   when:
-    - run__include_dw or run__force_teardown | bool
+    - run__include_dw
+    - not run__force_teardown | bool and not run__dw_force_delete | bool
     - run__env_info.environments | length > 0
-    - run__env_info.environments[0].descendants.dw | length > 0
-  cloudera.cloud.dw_cluster:
-    env: "{{ run__env_name }}"
+  block:
+    - name: Execute CDP Data Warehouse virtual warehouses (noncompactor VWs) teardown
+      cloudera.cloud.dw_virtual_warehouse:
+        cluster_id: "{{ __dw_cluster_id }}"
+        id: "{{ __vw_id.id }}"
+        state: absent
+        wait: yes
+      loop: "{{ __dw_vw_list.virtual_warehouses | default([]) }}"
+      loop_control:
+        loop_var: __vw_id
+        label: "{{ __vw_id.name }}"
+      register: __dw_vw_teardown_info
+      async: 3600 # 1 hour timeout
+      poll: 0
+
+    - name: Wait for CDP Data Warehouse virtual warehouses (noncompactor VWs) to decommission
+      ansible.builtin.async_status:
+        jid: "{{ __dw_vw_teardown_item.ansible_job_id }}"
+      loop_control:
+        loop_var: __dw_vw_teardown_item
+        label: "{{ __dw_vw_teardown_item.__vw_id.name }}"
+      loop: "{{ __dw_vw_teardown_info.results | default([]) }}"
+      register: __dw_vw_teardowns_async
+      until: __dw_vw_teardowns_async.finished
+      retries: 30
+      delay: 10
+  
+  rescue:
+    - name: Execute CDP Data Warehouse virtual warehouse teardown (compactor VWs)
+      cloudera.cloud.dw_virtual_warehouse:
+        cluster_id: "{{ __dw_cluster_id }}"
+        id: "{{ __dw_vw_compactor_item.__dw_vw_teardown_item.__vw_id.id }}"
+        state: absent
+        wait: yes
+      loop: "{{ ansible_failed_result.results }}"
+      when: __dw_vw_compactor_item.failed | bool
+      loop_control:
+        loop_var: __dw_vw_compactor_item
+        label: "{{ __dw_vw_compactor_item.__dw_vw_teardown_item.__vw_id.name }}"
+      register: __dw_vw_compactor_info
+      async: 3600 # 1 hour timeout
+      poll: 0
+
+    - name: Wait for CDP Data Warehouse virtual warehouses (compactor) to decommission
+      ansible.builtin.async_status:
+        jid: "{{ __dw_vw_compactor_teardown_item.ansible_job_id }}"
+      loop_control:
+        loop_var: __dw_vw_compactor_teardown_item
+        label: "{{ __dw_vw_compactor_teardown_item.__dw_vw_compactor_item.__dw_vw_teardown_item.__vw_id.name }}"
+      loop: "{{ __dw_vw_compactor_info.results }}"
+      when: __dw_vw_compactor_teardown_item.ansible_job_id is defined
+      register: __dw_vw_compactor_teardowns_async
+      until: __dw_vw_compactor_teardowns_async.finished
+      retries: 30
+      delay: 10
+
+- name: Execute CDP Data Warehouse database catalog teardown
+  when:
+    - run__include_dw
+    - not run__force_teardown | bool and not run__dw_force_delete | bool
+    - run__env_info.environments | length > 0
+  cloudera.cloud.dw_database_catalog:
+    cluster_id: "{{ __dw_cluster_id }}"
+    id: "{{ __dbc_id.id }}"
     state: absent
-    wait: no
-    force: "{{ run__dw_force_delete }}"
+    wait: yes
+  loop: "{{ __dw_dbc_list.database_catalogs | default([]) }}"
+  loop_control:
+    loop_var: __dbc_id
+    label: "{{ __dbc_id.name }}"
+  async: 3600 # 1 hour timeout
+  poll: 0
+  register: __dw_dbc_teardown_info
 
 - name: Execute CDP Dataflow teardown
-  register: __df_teardown_info
   when:
     - run__include_df or run__force_teardown | bool
-    - run__df_service_info is defined and run__df_service_info.services is defined
-    - run__df_service_info.services | length > 0
+    - run__df_env_info is defined and run__df_env_info.services is defined
+    - run__df_env_info.services | length > 0
   cloudera.cloud.df_service:
-    df_crn: "{{ __df_teardown_req_item.crn }}"
+    name: "{{ __df_teardown_req_item.crn }}"
     persist: "{{ run__df_persist }}"
     force: "{{ run__df_force_delete }}"
     terminate: "{{ run__df_terminate_deployments }}"
@@ -59,7 +125,8 @@
     wait: no
   loop_control:
     loop_var: __df_teardown_req_item
-  loop: "{{ run__df_service_info.services }}"
+  loop: "{{ run__df_env_info.services }}"
+  register: __df_teardown_info
 
 - name: Execute CDP ML Workspace teardown
   when:
@@ -164,15 +231,28 @@
   retries: 120
   delay: 30
 
-- name: Wait for CDP DW deployments to decommission
+- name: Wait for CDP Data Warehouse deployments to decommission
+  when: __dw_dbc_teardown_info is defined and __dw_dbc_teardown_info.results is defined # and not __dw_dbc_teardown_item.skipped
+  ansible.builtin.async_status:
+    jid: "{{ __dw_dbc_teardown_item.ansible_job_id }}"
+  loop_control:
+    loop_var: __dw_dbc_teardown_item
+    label: "{{ __dw_dbc_teardown_item.__dbc_id.name }}"
+  loop: "{{ __dw_dbc_teardown_info.results }}"
+  register: __dw_dbc_teardowns_async
+  until: __dw_dbc_teardowns_async.finished
+  retries: 120
+  delay: 30
+
+- name: Execute CDP Data Warehouse cluster teardown
   when:
-    - __dw_teardown_info is defined
-    - __dw_teardown_info.started | default(False)
+    - run__include_dw or run__force_teardown | bool
+    - run__env_info.environments | length > 0
   cloudera.cloud.dw_cluster:
     env: "{{ run__env_name }}"
     state: absent
     wait: yes
-    force: "{{ run__dw_force_delete }}"
+    force: "{{ run__dw_force_delete or run__force_teardown }}"
 
 - name: Wait for CDP OpDB deployments to decommission
   when:
@@ -193,9 +273,9 @@
 - name: Wait for CDP Dataflow Service to decommission
   when:
     - run__include_df
-    - run__df_service_info.services | length > 0
+    - run__df_env_info.services | length > 0
   cloudera.cloud.df_service:
-    df_crn: "{{ __df_teardown_wait_item.crn }}"
+    name: "{{ __df_teardown_wait_item.crn }}"
     persist: "{{ run__df_persist }}"
     force: "{{ run__df_force_delete }}"
     terminate: "{{ run__df_terminate_deployments }}"


### PR DESCRIPTION
This PR is to complete the work needed to enable (the happy path for) CDW creation and teardown.

At a high level it allows for:

- Creation of a CDW environment
- Creation of a default CDW database catalog
- Creation of non-default CDW database catalogs
- Loading demo data in non-default CDW database catalogs
- Creation of Hive and Impala VWs
- Specifying VW autoscaling min and max groups
- Specifying VW template/size
- Specifying VW tags
- Specifying Common and Application configs for VWs
- Enabling SSO for VWs
- Applying Group RBAC for VWs


It requires [CDPY PR 44](https://github.com/cloudera-labs/cdpy/pull/44)