### PR TITLE
Use infra__security_group_vpce_name as variable for VPC Endpoint SG

### DIFF
--- a/roles/infrastructure/tasks/setup_aws_network.yml
+++ b/roles/infrastructure/tasks/setup_aws_network.yml
@@ -253,7 +253,7 @@
         state: present
         region: "{{ infra__region }}"
         vpc_id: "{{ infra__aws_vpc_id }}"
-        tags: "{{ infra__tags | combine({ 'Name': 'infra__security_group_vpce_name' }, recursive=True) }}"
+        tags: "{{ infra__tags | combine({ 'Name': infra__security_group_vpce_name }, recursive=True) }}"
         name: "{{ infra__security_group_vpce_name }}"
         description: "{{ infra__security_group_vpce_name }}"
         rules:


### PR DESCRIPTION
Fixes #103 - use infra__security_group_vpce_name as variable instead of literal for VPC Endpoint SG. 

Signed-off-by: Jim Enright <jenright@cloudera.com>