### PR TITLE
RAZ impl in exe

### DIFF
--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -77,6 +77,7 @@ plat__xacccount_credential_name:              "{{ common__xaccount_credential_na
 plat__workload_analytics:                     "{{ env.workload_analytics | default(True) }}"
 plat__tunnel:                                 "{{ common__tunnel }}"
 plat__public_endpoint_access:                 "{{ common__public_endpoint_access }}"
+plat__enable_raz:                             "{{ env.datalake.enable_raz | default(False) }}"
 
 plat__env_admin_password:                     "{{ common__env_admin_password }}"
 
@@ -129,6 +130,7 @@ plat__aws_idbroker_role_name:                 "{{ common__aws_idbroker_role_name
 plat__aws_log_role_name:                      "{{ env.aws.role.name.log | default([plat__namespace, plat__aws_log_suffix, plat__aws_role_suffix] | join('-')) }}"
 plat__aws_datalake_admin_role_name:           "{{ common__aws_datalake_admin_role_name }}"
 plat__aws_ranger_audit_role_name:             "{{ env.aws.role.name.ranger_audit | default([plat__namespace, plat__aws_ranger_audit_suffix, plat__aws_role_suffix] | join('-')) }}"
+plat__aws_ranger_cloud_access_role_name:      "{{ env.aws.role.name.ranger_cloud_access | default(common__aws_datalake_admin_role_name) }}"
 
 plat__aws_xaccount_policy_name:               "{{ env.aws.policy.name.cross_account | default([plat__namespace, plat__aws_xaccount_suffix, plat__aws_policy_suffix] | join('-')) }}"
 plat__aws_idbroker_policy_name:               "{{ env.aws.policy.name.idbroker | default([plat__namespace, plat__aws_idbroker_suffix, plat__aws_policy_suffix] | join('-')) }}"

--- a/roles/platform/tasks/initialize_setup_aws.yml
+++ b/roles/platform/tasks/initialize_setup_aws.yml
@@ -24,6 +24,7 @@
     plat__aws_idbroker_role_arn: "arn:aws:iam::{{ __aws_caller_info.account }}:role/{{ plat__aws_idbroker_role_name }}"
     plat__aws_datalake_admin_role_arn: "arn:aws:iam::{{ __aws_caller_info.account }}:role/{{ plat__aws_datalake_admin_role_name }}"
     plat__aws_ranger_audit_role_arn: "arn:aws:iam::{{ __aws_caller_info.account }}:role/{{ plat__aws_ranger_audit_role_name }}"
+    plat__aws_ranger_cloud_access_role_arn: "arn:aws:iam::{{ __aws_caller_info.account }}:role/{{ plat__aws_ranger_cloud_access_role_name }}"
 
 - name: Discover CDP Cross Account information
   when: not plat__cdp_xaccount_external_id and not plat__cdp_xaccount_account_id

--- a/roles/platform/tasks/setup_aws_datalake.yml
+++ b/roles/platform/tasks/setup_aws_datalake.yml
@@ -23,6 +23,7 @@
     runtime: "{{ plat__datalake_version | default(omit) }}"
     scale: "{{ plat__datalake_scale | default(omit) }}"
     tags: "{{ plat__tags }}"
+    raz: "{{ plat__enable_raz }}"
     state: present
 
 - name: Retrieve AWS EC2 Instance details for CDP Datalake

--- a/roles/platform/tasks/setup_aws_idbroker.yml
+++ b/roles/platform/tasks/setup_aws_idbroker.yml
@@ -20,6 +20,7 @@
     sync: no
     data_access: "{{ plat__aws_datalake_admin_role_arn }}"
     ranger_audit: "{{ plat__aws_ranger_audit_role_arn }}"
+    ranger_cloud_access: "{{ (plat__enable_raz | bool) | ternary(plat__aws_ranger_cloud_access_role_arn, omit) }}"
     mappings:
       - accessor: "{{ plat__cdp_pub_admin_group_crn }}"
         role: "{{ plat__aws_datalake_admin_role_arn }}"


### PR DESCRIPTION
This PR adds RAZ support for AWS in cloudera.exe.

- Adds a switch for enabling RAZ (bool)
- Adds a default RAZ role (the DL Admin Role) and allows for specifying a custom RAZ role
- Updates the idbroker mapping task to pass the cloud authorizer role (RAZ)
- Updates the datalake creation task to pass the enableRAZ boolean

This PR needs to be tested in conjunction with [cloudera.cloud PR 55](https://github.com/cloudera-labs/cloudera.cloud/pull/55)