### PR TITLE
Fix MSI teardown to delete MSIs

### DIFF
--- a/roles/platform/tasks/initialize_teardown_azure.yml
+++ b/roles/platform/tasks/initialize_teardown_azure.yml
@@ -40,5 +40,5 @@
       - "{{ plat__azure_datalakeadmin_identity_name }}"
       - "{{ plat__azure_log_identity_name }}"
       - "{{ plat__azure_ranger_audit_identity_name }}"
-    role_assignment_assignee_list: "{{ msi_principal_id_list | union([plat__azure_application_service_principal_objuuid]) | list }}"
+    role_assignment_assignee_list: "{{ msi_principal_id_list | union([plat__azure_application_service_principal_objuuid | default([])]) | list }}"
     

--- a/roles/platform/tasks/teardown_azure_authz.yml
+++ b/roles/platform/tasks/teardown_azure_authz.yml
@@ -39,8 +39,6 @@
     api_version: '2018-11-30'
     idempotency: yes
     state: absent
-    body:
-      location: "{{ plat__region }}"
   loop:
     - "{{ plat__azure_idbroker_identity_name }}"
     - "{{ plat__azure_datalakeadmin_identity_name }}"
@@ -60,10 +58,10 @@
   delay: 5
   retries: 10
   until:
-    - plat__azure_idbroker_identity_name in discovered_msi_list
-    - plat__azure_datalakeadmin_identity_name in discovered_msi_list
-    - plat__azure_log_identity_name in discovered_msi_list
-    - plat__azure_ranger_audit_identity_name in discovered_msi_list
+    - plat__azure_idbroker_identity_name not in discovered_msi_list
+    - plat__azure_datalakeadmin_identity_name not in discovered_msi_list
+    - plat__azure_log_identity_name not in discovered_msi_list
+    - plat__azure_ranger_audit_identity_name not in discovered_msi_list
   vars:
     discovered_msi_list: "{{ __azure_identity_list.response | map(attribute='name') | list }}"
 


### PR DESCRIPTION
Bugfix PR for:

- Idempotency issue that was noticed due to troubleshooting
- Fix MSI deletion: deletion not occurring in task meant to perform the deletion. Silly Azure modules. Uncaught previously because tearing down the RG deletes everything in the RG (provided you say "delete_data") 

Signed-off-by: Christopher Perro <cmperro@gmail.com>