### PR TITLE
Update GCP for L2 networking deployment

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -149,6 +149,7 @@ common__datalake_name:                    "{{ env.datalake.name | default([commo
 common__datalake_name_suffix:             "{{ env.datalake.suffix | default(common__datalake_suffix) }}"
 common__tunnel:                           "{{ env.tunnel | default(False) }}"
 common__public_endpoint_access:           "{{ env.public_endpoint_access | default(not common__tunnel) }}"
+common__use_public_ip:                    "{{ env.public_endpoint_access | default(not common__tunnel) }}"
 
 common__env_admin_password:               "{{ globals.admin_password | mandatory }}"
 common__aws_policy_urls_default_root:     "https://raw.githubusercontent.com/hortonworks/cloudbreak/master/cloud-aws-common/src/main/resources/definitions/cdp"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -134,9 +134,12 @@ infra__gcp_project:                 "{{ common__gcp_project }}"
 infra__gcp_storage_location_data:   "{{ infra.gcp.storage.path.data | default([infra__storage_name, infra__data_path] | join('-')) }}"
 infra__gcp_storage_location_logs:   "{{ infra.gcp.storage.path.logs | default([infra__storage_name, infra__logs_path] | join('-')) }}"
 
-infra__gcp_cloud_router_name:       "{{ infra.gcp.network.router.name | default([infra__namespace, 'router'] | join('-')) }}"
-infra__gcp_cloud_router_asn:        "{{ infra.gcp.network.router.asn | default(64514) }}"
-infra__gcp_cloud_nat_name:          "{{ infra.gcp.network.nat.name | default([infra__namespace, 'nat'] | join('-')) }}"
+infra__gcp_cloud_router_name_suffix:  "{{ infra.gcp.network.router.name_suffix | default('router') }}"
+infra__gcp_cloud_router_name:         "{{ infra.gcp.network.router.name | default([infra__namespace, infra__gcp_cloud_router_name_suffix] | join('-')) }}"
+infra__gcp_cloud_router_asn:          "{{ infra.gcp.network.router.asn | default(64514) }}"
+
+infra__gcp_cloud_nat_name_suffix:   "{{ infra.gcp.network.nat.name_suffix | default('nat') }}"
+infra__gcp_cloud_nat_name:          "{{ infra.gcp.network.nat.name | default([infra__namespace, infra__gcp_cloud_nat_name_suffix] | join('-')) }}"
 
 # Azure
 infra__azure_metagroup_name:        "{{ common__azure_metagroup_name }}"

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -134,6 +134,10 @@ infra__gcp_project:                 "{{ common__gcp_project }}"
 infra__gcp_storage_location_data:   "{{ infra.gcp.storage.path.data | default([infra__storage_name, infra__data_path] | join('-')) }}"
 infra__gcp_storage_location_logs:   "{{ infra.gcp.storage.path.logs | default([infra__storage_name, infra__logs_path] | join('-')) }}"
 
+infra__gcp_cloud_router_name:       "{{ infra.gcp.network.router.name | default([infra__namespace, 'router'] | join('-')) }}"
+infra__gcp_cloud_router_asn:        "{{ infra.gcp.network.router.asn | default(64514) }}"
+infra__gcp_cloud_nat_name:          "{{ infra.gcp.network.nat.name | default([infra__namespace, 'nat'] | join('-')) }}"
+
 # Azure
 infra__azure_metagroup_name:        "{{ common__azure_metagroup_name }}"
 

--- a/roles/infrastructure/tasks/setup_gcp_network.yml
+++ b/roles/infrastructure/tasks/setup_gcp_network.yml
@@ -74,3 +74,42 @@
     --network={{ infra__vpc_name }}
     --service=servicenetworking.googleapis.com
     --ranges={{ infra__vpc_svcnet_name }}
+
+# Cloud Router and Cloud NAT for L2 networking
+- name: Create a Cloud Router
+  when: 
+    - infra__tunnel
+    - not infra__public_endpoint_access 
+  google.cloud.gcp_compute_router:
+    name: "{{ infra__gcp_cloud_router_name }}"
+    network: "{{ __gcp_vpc_info }}"
+    bgp:
+      asn: "{{ infra__gcp_cloud_router_asn }}"
+      advertise_mode: DEFAULT
+    region: "{{ infra__region }}"
+    project: "{{ infra__gcp_project }}"
+    state: present
+
+- name: Discover Cloud NAT and Create if required
+  when:
+    - infra__tunnel
+    - not infra__public_endpoint_access 
+  block:
+    - name: Discover Cloud NAT
+      ansible.builtin.command: >
+        gcloud compute routers nats describe {{ infra__gcp_cloud_nat_name }}        
+        --router={{ infra__gcp_cloud_router_name }}
+        --router-region={{ infra__region }}
+      ignore_errors: true
+      register: __gcp_nat_discovered
+
+    - name: Create Cloud NAT if not discovered
+      when:
+        - __gcp_nat_discovered is failed 
+      ansible.builtin.command: >
+        gcloud compute routers nats create {{ infra__gcp_cloud_nat_name }}
+        --router={{ infra__gcp_cloud_router_name }}
+        --router-region={{ infra__region }}
+        --auto-allocate-nat-external-ips
+        --nat-all-subnet-ip-ranges
+        --enable-logging

--- a/roles/infrastructure/tasks/teardown_gcp_network.yml
+++ b/roles/infrastructure/tasks/teardown_gcp_network.yml
@@ -32,6 +32,34 @@
         name: "{{ infra__security_group_default_name }}"
         state: absent
 
+
+# CREATE NAT
+- name: Discover Cloud NAT and Delete if required
+  block:
+    - name: Delete Cloud NAT
+      ansible.builtin.command: >
+        gcloud compute routers nats describe {{ infra__gcp_cloud_nat_name }}        
+        --router={{ infra__gcp_cloud_router_name }}
+        --router-region={{ infra__region }}
+      ignore_errors: true
+      register: __gcp_nat_discovered
+
+    - name: Delete Cloud NAT if discovered
+      when:
+        - __gcp_nat_discovered is succeeded 
+      ansible.builtin.command: >
+        gcloud compute routers nats delete {{ infra__gcp_cloud_nat_name }}        
+        --router={{ infra__gcp_cloud_router_name }}
+        --router-region={{ infra__region }}
+
+    - name: Delete a Cloud Router
+      google.cloud.gcp_compute_router:
+        name: "{{ infra__gcp_cloud_router_name }}"
+        network: "{{ __gcp_vpc_info }}"
+        region: "{{ infra__region }}"
+        project: "{{ infra__gcp_project }}"
+        state: absent
+
     - name: Remove GCP VPC Subnets
       google.cloud.gcp_compute_subnetwork:
         region: "{{ infra__region }}"

--- a/roles/infrastructure/tasks/teardown_gcp_network.yml
+++ b/roles/infrastructure/tasks/teardown_gcp_network.yml
@@ -32,8 +32,6 @@
         name: "{{ infra__security_group_default_name }}"
         state: absent
 
-
-# CREATE NAT
 - name: Discover Cloud NAT and Delete if required
   block:
     - name: Delete Cloud NAT

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -78,6 +78,7 @@ plat__workload_analytics:                     "{{ env.workload_analytics | defau
 plat__tunnel:                                 "{{ common__tunnel }}"
 plat__public_endpoint_access:                 "{{ common__public_endpoint_access }}"
 plat__enable_raz:                             "{{ env.datalake.enable_raz | default(False) }}"
+plat__use_public_ip:                          "{{ common__use_public_ip }}"
 
 plat__env_admin_password:                     "{{ common__env_admin_password }}"
 

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -22,7 +22,7 @@
     cloud: "{{ plat__infra_type }}"
     region: "{{ plat__region }}"
     public_key_text: "{{ plat__public_key_text }}"
-    public_ip: yes
+    public_ip: "{{ plat__use_public_ip }}"
     log_location: "gs://{{ plat__gcp_storage_location_logs }}"
     log_identity: "{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
     vpc_id: "{{ plat__vpc_name }}"


### PR DESCRIPTION
Update to infrastructure and platform roles to support an L2 networking deployment on GCP.
Summary of changes:
* In infra 
  * Created a Cloud Router and Cloud NAT. These are required to communicate with the Control Plane when setting up the environment resources.
  * Removes these resources during teardown.
* In platform
 * updated the `use_public_ip` parameter in the `cloudera.cloud.env` call to follow the value of `env.public_endpoint_access`.

Tested these changes to confirm that L2 environment was successfully deployed. Also tested that teardown completes successfully.

Changes done in collaboration with Jeremy Wietrzykowski (@ws30)