### PR TITLE
Remove calls to the unsupported cloudera.cloud.env_auth

### DIFF
--- a/roles/platform/tasks/setup_base.yml
+++ b/roles/platform/tasks/setup_base.yml
@@ -24,12 +24,6 @@
   ansible.builtin.set_fact:
     plat__cdp_env_crn: "{{ plat__cdp_env_info.environments[0].crn }}"
 
-- name: Set CDP Workload password
-  cloudera.cloud.env_auth:
-    password: "{{ plat__env_admin_password }}"
-    name: "{{ plat__env_name }}"
-    strict: false
-
 - name: Set fact for CDP Admin Group Resource Role assignments
   ansible.builtin.set_fact:
     plat__cdp_env_admin_group_resource_role_assignments: "{{ plat__cdp_env_admin_group_resource_role_assignments | default([]) | union([resource_role_assignment]) }}"


### PR DESCRIPTION
We were notified that support for setting different passwords for each environment is not support.

The CLI command `cdp environments set-password` is deprecated and soon to be removed. This PR removes the call to `cloudera.cloud.env_auth` (which calls the same SDK endpoint) from the cloudera.exe codebase.

Signed-off-by: Jim Enright <jenright@cloudera.com>