### PR TITLE
WIP PvC Prereqs and Control Plane merge

### DIFF
--- a/requirements_azure.txt
+++ b/requirements_azure.txt
@@ -14,8 +14,8 @@
 
 # Azure
 
-# NOTE: The Azure CLI is installed as a OS package.
+# NOTE: The Azure CLI is installed as an OS package.
 
 # Azure Collection requirements, which are distinct from Azure CLI
 -r https://raw.githubusercontent.com/ansible-collections/azure/dev/requirements-azure.txt
-azure-mgmt-netapp>=1.0.0    # NetApp Collection requirements
+azure-mgmt-netapp>=8.0.0    # NetApp Collection requirements

--- a/requirements_gcp.txt
+++ b/requirements_gcp.txt
@@ -15,4 +15,4 @@
 # Google Cloud
     
 # NOTE: google-cloud-sdk, including the CLI, is installed as OS package.
-google-auth
+google-auth>=2.9.0

--- a/roles/auto_repo_mirror/defaults/main.yml
+++ b/roles/auto_repo_mirror/defaults/main.yml
@@ -1,0 +1,3 @@
+default_enable_auto_repo_mirror: no
+default_download_link_expiry: 3600
+default_auto_repo_mirror_prefix: cache

--- a/roles/auto_repo_mirror/tasks/inject.yml
+++ b/roles/auto_repo_mirror/tasks/inject.yml
@@ -1,0 +1,129 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Check if Download Mirror cache file exists
+  register: __auto_repo_mirror_file_stat
+  ansible.builtin.stat:
+    path: "{{ init__auto_repo_mirror_artefact }}"
+
+- name: Prepare for Download Mirror parsing
+  when:
+    - __auto_repo_mirror_file_stat.stat.exists
+    - use_auto_repo_mirror | default(default_enable_auto_repo_mirror) | bool
+  block:
+    - name: Check a custom_repo is part of the cluster definition if using Download Mirror
+      when: use_auto_repo_mirror | default(default_enable_auto_repo_mirror) | bool
+      ansible.builtin.assert:
+        that: "'custom_repo' in groups"
+        fail_msg: "You must have a custom_repo in your Cluster Inventory when using Download Mirror"
+
+    - name: Handle AWS cache key generation
+      when: globals.infra_type == 'aws'
+      block:
+        - name: Get AWS Account Info
+          amazon.aws.aws_caller_info:
+          register: __aws_caller_info
+
+        - name: Set parcel cache ini lookup key
+          ansible.builtin.set_fact:
+            init__auto_repo_mirror_ini_key: "{{ __aws_caller_info.account }}"
+
+# Ini lookup fails when section is not present, but lacks good control characteristics that I can find
+- name: Determine if there is a relevant cache entry
+  when:
+    - init__auto_repo_mirror_ini_key is defined
+    - use_auto_repo_mirror | default(default_enable_auto_repo_mirror) | bool
+  ignore_errors: yes
+  ansible.builtin.set_fact:
+    __auto_repo_mirror_ini_entry: "{{ lookup('ini', __ini_lookup) }}"
+  vars:
+    __ini_lookup: ".+{{ init__auto_repo_mirror_ini_key }}.+ section={{ globals.infra_type }}:{{ globals.region }} file={{ init__auto_repo_mirror_artefact }} re=yes"
+
+- name: Handle Download Mirror injection if cache entry found
+  when:
+    - __auto_repo_mirror_ini_entry is defined
+  block:
+    - name: Generate a unique name
+      set_fact:
+        __tmp_cluster_file: "{{ ['/tmp', 99999999 | random | to_uuid] | path_join }}"
+
+    - name: Copy Cluster definition to temp file
+      copy:
+        src: "{{ init__cluster_definition_file }}"
+        dest: "{{ __tmp_cluster_file }}"
+
+    - name: Inject Parcel cache entries to Repository URLs
+      ansible.builtin.replace:
+        name: "{{ __tmp_cluster_file }}"
+        regexp: '^(\s+\-\s)https://archive\.cloudera\.com(\/.+)$'
+        replace: '\1http://{{ groups.custom_repo | first }}\2'
+
+    - name: Set Cluster Definition file to Temp file with parcel cache entries
+      ansible.builtin.set_fact:
+        init__cluster_definition_file: "{{ __tmp_cluster_file }}"
+
+    - name: Fetch repositories from cluster definition
+      ansible.builtin.set_fact:
+        init__preparse_repo_listing: "{{ lookup('file', init__cluster_definition_file ) | from_yaml | json_query('clusters[*].repositories') | flatten }}"
+
+    - name: Prepare lookup list of Repository entries
+      loop: "{{ init__preparse_repo_listing }}"
+      loop_control:
+        loop_var: __cluster_repo_item
+      ansible.builtin.set_fact:
+        init__cluster_repo_entries: "{{ init__cluster_repo_entries | default([]) + [__cluster_repo_item | urlsplit('path') ] }}"
+
+    - name: Create list of Download Mirror URLs filtered to required repositories and distros
+      loop: "{{ init__cluster_repo_entries }}"
+      loop_control:
+        loop_var: __cluster_repo_path_item
+      ansible.builtin.set_fact:
+        init__urls_to_sign: "{{ init__urls_to_sign
+          | default([]) + __auto_repo_mirror_ini_entry
+          | select('search', __cluster_repo_path_item)
+          | select('search', init__parcel_distro)
+          | list }}"
+
+    - name: Ensure manifest is included in Download Mirror URLs if present
+      loop: "{{ init__cluster_repo_entries }}"
+      loop_control:
+        loop_var: __cluster_repo_path_item
+      ansible.builtin.set_fact:
+        init__urls_to_sign: "{{ init__urls_to_sign
+            | default([]) + __auto_repo_mirror_ini_entry
+            | select('search', 'manifest.json')
+            | list }}"
+
+- name: Get AWS Specific download URIs
+  when:
+    - globals.infra_type == 'aws'
+    - init__urls_to_sign is defined
+  block:
+    - name: Generate signed URIs for hosted parcels to be pulled into custom_repo
+      register: __s3_signed_uris
+      loop: "{{ init__urls_to_sign }}"
+      loop_control:
+        loop_var: __s3_bucket_uri
+      amazon.aws.aws_s3:
+        bucket: "{{ __s3_bucket_uri | regex_replace('^.+//(.+)\\.s3.+$', '\\1') }}"
+        object: "{{ __s3_bucket_uri | regex_replace('^.+amazonaws\\.com(.+)$', '\\1') }}"
+        ignore_nonexistent_bucket: yes
+        expiry: "{{ download_link_expiry | default(default_download_link_expiry) }}"
+        mode: geturl
+
+    - name: Set List of files to download to custom_repo
+      ansible.builtin.set_fact:
+        auto_repo_mirror_file_list: "{{ __s3_signed_uris.results | json_query('[*].url') | list  }}"

--- a/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
+++ b/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
@@ -56,7 +56,13 @@
   loop_control:
     loop_var: __filtered_parcel_item
   ansible.builtin.set_fact:
-    init__file_mirror_targets: "{{ init__file_mirror_targets | default(__init_tarball_links) + [__filtered_parcel_item, __filtered_parcel_item + '.sha1', __filtered_parcel_item.replace(__filtered_parcel_item | basename, 'manifest.json') ] }}"
+    init__file_mirror_targets: "{{ init__file_mirror_targets | default(__init_tarball_links) + [__filtered_parcel_item, __filtered_parcel_item + '.sha1', __filtered_parcel_item + '.sha', __filtered_parcel_item.replace(__filtered_parcel_item | basename, 'manifest.json') ] }}"
+
+# Explicitly set version from parcel distro as Ansible controller could be different OS from target cluster
+- name: Determine Cloudera-Manager Distro and Version
+  ansible.builtin.set_fact:
+    init__cloudera_manager_distro_name: "{{ cm_distro_select[init__parcel_distro]['name'] }}"
+    init__cloudera_manager_distro_version: "{{ cm_distro_select[init__parcel_distro]['version'] }}"
 
 # This sets 'cloudera_manager_repo_url' on the calling host
 - name: Determine Cloudera Manager Repo
@@ -65,6 +71,8 @@
   vars:
     install_repo_on_host: no
     clusters: []
+    cloudera_manager_distro_name: "{{ init__cloudera_manager_distro_name }}"
+    cloudera_manager_distro_version: "{{ init__cloudera_manager_distro_version }}"
 
 - name: Add Cloudera Manager Repo to File Mirror list
   ansible.builtin.set_fact:

--- a/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
+++ b/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
@@ -1,0 +1,115 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Read in cluster definition without jinja parsing=
+- name: Fetch repositories from cluster definition
+  ansible.builtin.set_fact:
+    init__preparse_repo_listing: "{{ lookup('file', init__cluster_definition_file ) | from_yaml | json_query('clusters[*].repositories') | flatten }}"
+
+- name: Check that a Cloudera License is presented if mirroring from files behind Cloudera Subscription
+  when: init__preparse_repo_listing | select('search', 'archive.cloudera.com/p') | length > 0
+  ansible.builtin.assert:
+    that:
+      - globals.cloudera_license_file is defined
+      - globals.cloudera_license_file | length > 0
+    fail_msg: "You must Supply a Cloudera License file to download and mirror files from archive.cloudera.com"
+
+- name: Separate direct Repos from tarballs and set Initial Facts
+  ansible.builtin.set_fact:
+    __init_parcel_repos: "{{ init__preparse_repo_listing | reject('search', 'tar.gz') | default([]) }}"
+    __init_tarball_links: "{{ init__preparse_repo_listing | select('search', 'tar.gz') | default([]) }}"
+
+# This sets 'manifests' on the calling host, and provides the repo login details
+- name: Get Parcel Manifests
+  ansible.builtin.include_role:
+    name: cloudera.cluster.deployment.repometa
+    public: yes
+  vars:
+    repositories: "{{ __init_parcel_repos }}"
+    cluster_os_distribution: "{{ init__parcel_distro }}"
+
+- name: Extract Parcel URLs from Manifests
+  ansible.builtin.set_fact:
+    __parcel_urls: "{{ manifests.results | cloudera.cluster.extract_parcel_urls }}"
+    __parcel_distro_search_term: "{{ init__parcel_distro }}.parcel"
+
+- name: Filter Parcels by distro
+  ansible.builtin.set_fact:
+    __filtered_parcel_urls: "{{ __parcel_urls | select('search', __parcel_distro_search_term ) | list }}"
+
+- name: Prepare target Download Mirror listing with parcels and attendant files
+  when: __filtered_parcel_urls | length > 0
+  loop: "{{ __filtered_parcel_urls }}"
+  loop_control:
+    loop_var: __filtered_parcel_item
+  ansible.builtin.set_fact:
+    init__file_mirror_targets: "{{ init__file_mirror_targets | default(__init_tarball_links) + [__filtered_parcel_item, __filtered_parcel_item + '.sha1', __filtered_parcel_item.replace(__filtered_parcel_item | basename, 'manifest.json') ] }}"
+
+# This sets 'cloudera_manager_repo_url' on the calling host
+- name: Determine Cloudera Manager Repo
+  ansible.builtin.include_role:
+    role: cloudera.cluster.cloudera_manager.repo
+  vars:
+    install_repo_on_host: no
+    clusters: []
+
+- name: Add Cloudera Manager Repo to File Mirror list
+  ansible.builtin.set_fact:
+    init__file_mirror_targets: "{{ init__file_mirror_targets + [cloudera_manager_repo_url | regex_replace('^(.+\\/(\\d\\.\\d\\.\\d)\\/)(\\w+)\\/.+$', '\\1' + 'repo-as-tarball/cm' + '\\2' + '-' + '\\3' + '.tar.gz')] }}"
+
+- name: Include CSDs if set
+  when:
+    - cloudera_manager_csds is defined
+    - cloudera_manager_csds | length > 0
+  ansible.builtin.set_fact:
+    init__file_mirror_targets: "{{ init__file_mirror_targets + cloudera_manager_csds }}"
+
+- name: Resolve Download Mirror for AWS
+  when: globals.infra_type == 'aws'
+  block:
+    - name: Get AWS Account Info
+      amazon.aws.aws_caller_info:
+      register: __aws_caller_info
+
+    - name: Prepare Localised Download Mirror utility bucket name
+      ansible.builtin.set_fact:
+        init__auto_repo_mirror_bucket_name: "{{ utility_bucket_name | default([ auto_repo_mirror_prefix | default(default_auto_repo_mirror_prefix), __aws_caller_info.account, globals.region ] | join('-') ) }}"
+
+    - name: List current target cache contents if any exist
+      register: __auto_repo_mirror_lookup_initial
+      failed_when:
+        - __auto_repo_mirror_lookup_initial.s3_keys is not defined
+        - "'cannot be found' not in __auto_repo_mirror_lookup_initial.msg"
+      amazon.aws.aws_s3:
+        bucket: "{{ init__auto_repo_mirror_bucket_name }}"
+        mode: list
+
+    - name: Filter Files not already in mirror to be downloaded
+      when: __auto_repo_mirror_lookup_initial.s3_keys is defined
+      loop: "{{ __auto_repo_mirror_lookup_initial.s3_keys }}"
+      loop_control:
+        loop_var: __init_s3key_item
+      ansible.builtin.set_fact:
+        init__file_mirror_targets: "{{ init__file_mirror_targets | reject('match', '^.+' + __init_s3key_item + '$') | list }}"
+
+- name: Set Download Mirror details in Globals
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine( __auto_repo_mirror_spec, recursive=True ) }}"
+  vars:
+    __auto_repo_mirror_spec:
+      auto_repo_mirror_targets: "{{ init__file_mirror_targets }}"
+      utility_bucket_name: "{{ init__auto_repo_mirror_bucket_name }}"
+      create_utility_service: init__file_mirror_targets | length > 0 | bool

--- a/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
+++ b/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
@@ -48,6 +48,7 @@
     jid: "{{ __download_async_item.ansible_job_id }}"
   failed_when:
     - __download_async_item.failed == True
+    - __download_async_item.status_code != 404
     - __download_async_item.finished != 1
 
 # Unpack parcel tarballs

--- a/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
+++ b/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
@@ -1,0 +1,136 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Ensure paths exist for File downloads to match required object structure [ will retry while utility VM boots ]
+  loop: "{{ globals.auto_repo_mirror_targets }}"
+  loop_control:
+    loop_var: __tmp_mirror_dir_item
+  ansible.builtin.file:
+    path: "/tmp/{{ globals.utility_bucket_name }}{{ __tmp_mirror_dir_item | urlsplit('path') | dirname }}"
+    state: directory
+
+- name: Request Async Download of Files to path structure
+  when: globals.auto_repo_mirror_targets
+  register: __auto_repo_mirror_rehost_results
+  loop: "{{ globals.auto_repo_mirror_targets }}"
+  loop_control:
+    loop_var: __mirror_fetch_item
+  async: 7200
+  poll: 0
+  ansible.builtin.get_url:
+    url: "{{ __mirror_fetch_item }}"
+    dest: "/tmp/{{ globals.utility_bucket_name }}{{ __mirror_fetch_item | urlsplit('path') }}"
+    url_username: "{{ cloudera_manager_repo_username | default(omit) }}"
+    url_password: "{{ cloudera_manager_repo_password | default(omit)  }}"
+
+- name: Track async downloads to completion  [ This may take up to an hour the first time for multi-gb Parcels ]
+  loop: "{{ __auto_repo_mirror_rehost_results.results }}"
+  loop_control:
+    loop_var: __download_async_item
+  register: __async_download_results
+  until: __async_download_results.finished is defined and __async_download_results.finished
+  delay: 30
+  retries: 240
+  async_status:
+    jid: "{{ __download_async_item.ansible_job_id }}"
+  failed_when:
+    - __download_async_item.failed == True
+    - __download_async_item.finished != 1
+
+# Unpack parcel tarballs
+- name: Unpack parcel tarballs for convenient use
+  loop: "{{ globals.auto_repo_mirror_targets | select('search', 'parcels.tar.gz') | list }}"
+  loop_control:
+    loop_var: __parcel_unpack_item
+  ansible.builtin.unarchive:
+    extra_opts: [ --strip-components=1 ]
+    remote_src: yes
+    src: "/var/www/html{{ __parcel_unpack_item | urlsplit('path') }}"
+    dest: "/var/www/html{{ __parcel_unpack_item | urlsplit('path') | dirname }}"
+    keep_newer: yes
+
+- name: Upload Download Mirror for AWS to S3
+  when: globals.infra_type == 'aws'
+  block:
+    # Prepare to sync cache dir to S3
+    - name: Setup System Rhel8
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int >= 8
+      become: yes
+      ansible.builtin.package:
+        lock_timeout: 180
+        name: "{{ __package_item }}"
+        update_cache: yes
+        state: present
+      loop_control:
+        loop_var: __package_item
+      loop:
+        - epel-release
+        - python3
+
+    - name: Setup system Rhel7
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version | int < 8
+      become: yes
+      ansible.builtin.package:
+        name: "{{ __package_item }}"
+        state: present
+        lock_timeout: "{{ (ansible_os_family == 'RedHat') | ternary(180, omit) }}"
+      loop_control:
+        loop_var: __package_item
+      loop:
+        - epel-release
+        - python-pip
+
+    - name: Setup system Debian
+      when: ansible_os_family == "Debian"
+      block:
+        - name: enable Debian Repos
+          become: yes
+          apt_repository:
+            repo: "{{ __repo_item }}"
+          loop_control:
+            loop_var: __repo_item
+          loop:
+            - "deb http://archive.ubuntu.com/ubuntu/ {{ globals.dynamic_inventory.vm.os }} universe"
+            - "deb http://archive.ubuntu.com/ubuntu/ {{ globals.dynamic_inventory.vm.os }}-updates universe"
+            - "deb http://security.ubuntu.com/ubuntu/ {{ globals.dynamic_inventory.vm.os }}-security universe"
+
+        - name: Install Pip on Debian
+          become: yes
+          ansible.builtin.apt:
+            update_cache: yes
+            name: python3-pip
+            state: present
+
+    - name: Prepare host for s3 actions
+      become: yes
+      ansible.builtin.pip:
+        name: "{{ __pip_item }}"
+      loop_control:
+        loop_var: __pip_item
+      loop:
+        - futures
+        - "{{ (ansible_python_version[0] == '2') | ternary('boto3 >= 1.4.4,<1.18', 'boto3 >= 1.20.0') }}"
+
+    - name: Sync downloaded Files paths to S3 cache bucket
+      become: yes
+      community.aws.s3_sync:
+        bucket: "{{ globals.utility_bucket_name }}"
+        file_root: "/tmp/{{ globals.utility_bucket_name }}"
+        permission: private

--- a/roles/auto_repo_mirror/tasks/prepare_auto_repo_mirror.yml
+++ b/roles/auto_repo_mirror/tasks/prepare_auto_repo_mirror.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Fetch necessary variables from Ansible Controller
+  ansible.builtin.set_fact:
+    globals: "{{ hostvars['localhost']['globals'] }}"
+
+- name: Prepare Cloudera Subscription Credentials
+  ansible.builtin.include_role:
+    name: cloudera.cluster.deployment.credential
+  when: globals.cloudera_license_file is defined
+  vars:
+    cloudera_manager_license_file: "{{ globals.cloudera_license_file }}"
+
+- name: Populate the Download Mirror with new files
+  when: globals.auto_repo_mirror_targets | length > 0
+  ansible.builtin.include_role:
+    name: cloudera.exe.auto_repo_mirror
+    tasks_from: populate_from_upstream

--- a/roles/auto_repo_mirror/tasks/update_mirror_cache.yml
+++ b/roles/auto_repo_mirror/tasks/update_mirror_cache.yml
@@ -1,0 +1,31 @@
+---
+
+- name: Refresh Listing of target cache contents
+  when:
+    - init__auto_repo_mirror_bucket_name is defined
+    - "'teardown' not in ansible_run_tags"
+  register: __infra_auto_repo_mirror_listing
+  failed_when:
+    - __auto_repo_mirror_lookup_initial.s3_keys is not defined
+    - "'cannot be found' not in __auto_repo_mirror_lookup_initial.msg"
+  amazon.aws.aws_s3:
+    bucket: "{{ init__auto_repo_mirror_bucket_name }}"
+    mode: list
+
+- name: Prepare updated Download Mirror contents as URLs
+  when: __infra_auto_repo_mirror_listing.s3_keys is defined
+  loop: "{{ __infra_auto_repo_mirror_listing.s3_keys }}"
+  loop_control:
+    loop_var: __auto_repo_mirror_s3_urls_item
+  ansible.builtin.set_fact:
+    __auto_repo_mirror_url_listing: "{{ __auto_repo_mirror_url_listing | default([]) + [['https:/', init__auto_repo_mirror_bucket_name + '.s3.amazonaws.com', __auto_repo_mirror_s3_urls_item ] | join('/') ] }}"
+
+- name: Persist Download Mirror to Definition path
+  when:
+    - __auto_repo_mirror_url_listing is defined
+    - __auto_repo_mirror_url_listing | length > 0
+  community.general.ini_file:
+    path: "{{ init__auto_repo_mirror_artefact }}"
+    section: "{{ globals.infra_type }}:{{ globals.region }}"
+    option: "{{ init__auto_repo_mirror_bucket_name }}"
+    value: "{{ __auto_repo_mirror_url_listing }}"

--- a/roles/auto_repo_mirror/vars/main.yml
+++ b/roles/auto_repo_mirror/vars/main.yml
@@ -1,0 +1,13 @@
+cm_distro_select:
+  el7:
+    name: redhat
+    version: 7
+  el8:
+    name: redhat
+    version: 8
+  bionic:
+    name: ubuntu
+    version: 1804
+  focal:
+    name: ubuntu
+    version: 2004

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -157,7 +157,7 @@ common__aws_policy_urls_default_root:     "https://raw.githubusercontent.com/hor
 common__setup_runtime:                    "{{ ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) | bool }}"
 common__setup_plat:                       "{{ env is defined or sequence__setup_runtime  | default(False) | bool }}"
 common__setup_infra:                      "{{ infra is defined or sequence__setup_plat | default(False) | bool }}"
-common__setup_base:                       "{{ mgmt is defined or clusters is defined | default(False) | bool }}"
+common__setup_base:                       "{{ mgmt is defined | default(False) | bool }}"
 
 common__include_ml:                        "{{ ml is defined | bool }}"
 common__include_dw:                        "{{ dw is defined | bool }}"

--- a/roles/dynamic_inventory/defaults/main.yml
+++ b/roles/dynamic_inventory/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+default_inventory_template: "inventory_template.ini"
+default_static_inventory: "inventory_static.ini"
+
+init__dynamic_inventory_template: "{{ abs_template | default( [definition_path, inventory_template | default(default_inventory_template)] | path_join ) }}"
+init__dynamic_inventory_artefact: "{{ abs_inventory | default( [definition_path, static_inventory | default(default_static_inventory)] | path_join ) }}"

--- a/roles/dynamic_inventory/tasks/create_static_inventory.yml
+++ b/roles/dynamic_inventory/tasks/create_static_inventory.yml
@@ -1,0 +1,62 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Generate a unique name
+  ansible.builtin.set_fact:
+    __tmp_dynamic_inventory_artefact: "{{ [inventory_dir, 99999999 | random | to_uuid] | path_join }}"
+
+- name: Copy Host Inventory Template to Temporary Static Inventory Artefact
+  ansible.builtin.copy:
+    src: "{{ init__dynamic_inventory_template }}"
+    dest: "{{ __tmp_dynamic_inventory_artefact }}"
+
+- name: Update Static Inventory Artefact with Host Entries from Cloud Infrastructure Run
+  loop: "{{ __dynamic_inventory_host_list | zip( infra__dynamic_inventory_host_entries ) }}"
+  loop_control:
+    loop_var: __infra_inventory_compute_item
+  ansible.builtin.replace:
+    name: "{{ __tmp_dynamic_inventory_artefact }}"
+    regexp: '(\s+){{ __infra_inventory_compute_item.0 }}(\s+)'
+    replace: '\1{{ __infra_inventory_compute_item.1 }}\2'
+
+- name: Stat the Temporary Artefact
+  ansible.builtin.stat:
+    path: "{{ __tmp_dynamic_inventory_artefact }}"
+  register: __tmp_inventory_static
+
+- name: Check for an existing Dynamic Inventory Artefact file
+  ansible.builtin.stat:
+    path: "{{ init__dynamic_inventory_artefact }}"
+  register: __inventory_static
+
+- name: Create a backup if the files are different
+  when:
+    - __inventory_static.stat.exists
+    - __tmp_inventory_static.stat.checksum != __inventory_static.stat.checksum
+  ansible.builtin.copy:
+    src: "{{ __inventory_static.stat.path }}"
+    dest: "{{ [init__dynamic_inventory_artefact | splitext | first, ansible_date_time.epoch] | join('.') }}"
+
+- name: Copy Temporary Dynamic Inventory Artefact to Inventory Artefact
+  ansible.builtin.copy:
+    src: "{{ __tmp_inventory_static.stat.path }}"
+    dest: "{{ init__dynamic_inventory_artefact }}"
+    force: yes
+
+- name: Remove Temporary Artefact file
+  ansible.builtin.file:
+    path: "{{ __tmp_inventory_static.stat.path }}"
+    state: absent

--- a/roles/dynamic_inventory/tasks/parse_inventory_template.yml
+++ b/roles/dynamic_inventory/tasks/parse_inventory_template.yml
@@ -1,0 +1,50 @@
+# Read in Dynamic Inventory
+- name: Seek Inventory Template in Definition Path
+  register: __di_template_stat
+  ansible.builtin.stat:
+    path: "{{ init__dynamic_inventory_template }}"
+
+# inventory_dir is not defined when a user passes in an inventory with -i, so it is a useful check
+# No point loading Dynamic Inventory if we are not doing infrastructure in this run
+- name: Handle Dynamic Inventory Template
+  when:
+    - inventory_dir is defined
+    - __di_template_stat.stat.exists
+  block:
+    - name: Load in Dynamic Inventory Template
+      include_tasks: refresh_inventory.yml
+      vars:
+        include_inventory_file: "{{ __di_template_stat.stat.path }}"
+
+    - name: Print Dynamic Inventory groups to debug at Verbosity 3
+      debug:
+        msg: "{{ groups }}"
+        verbosity: 3
+
+    - name: Check expected minimum host groups appear in Inventory
+      ansible.builtin.assert:
+        quiet: yes
+        that:
+          - groups.cluster is defined
+          - groups.cloudera_manager is defined
+        fail_msg: "Parsed Inventory Template did not contain minimum expected groups for a Cloudera Cluster deployment"
+
+    - name: Extract list of hosts from Dynamic Inventory Template
+      when: groups.all | length > 0
+      ansible.builtin.set_fact:
+        __dynamic_inventory_host_list: "{{ groups.all | difference(['localhost']) }}"
+
+    - name: Set Dynamic Inventory host count in Globals
+      when: __dynamic_inventory_host_list | length > 0
+      ansible.builtin.set_fact:
+        globals: "{{ globals | default({}) | combine( __di_entry | default(omit), recursive=True ) }}"
+      loop_control:
+        loop_var: __di_entry
+      loop:
+        - dynamic_inventory:
+            vm:
+              count: "{{ __dynamic_inventory_host_list | count }}"
+              os: "{{ init__parcel_distro }}"
+  always:
+    - name: Remove Dynamic Inventory Template from current inventory
+      include_tasks: refresh_inventory.yml

--- a/roles/dynamic_inventory/tasks/refresh_inventory.yml
+++ b/roles/dynamic_inventory/tasks/refresh_inventory.yml
@@ -1,0 +1,53 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# TODO Consider converting to a handler?
+
+- name: Check for additional inventory file
+  ansible.builtin.stat:
+    path: "{{ include_inventory_file | default('') }}"
+  register: __add_inventory_static
+
+- name: Generate a unique name
+  when:
+    - __add_inventory_static.stat.exists
+    - inventory_dir is defined
+  ansible.builtin.set_fact:
+    __tmp_add_inventory_file: "{{ [inventory_dir, 99999999 | random | to_uuid] | path_join }}"
+
+- name: Temporarily copy Additional Inventory to Ansible inventory dir {{ inventory_dir }}
+  when:
+    - __add_inventory_static.stat.exists
+    - inventory_dir is defined
+  ansible.builtin.copy:
+    src: "{{ __add_inventory_static.stat.path }}"
+    dest: "{{ __tmp_add_inventory_file }}"
+
+- name: Refresh inventory
+  meta: refresh_inventory
+
+- name: Remove temporary static inventory file
+  when:
+    - __add_inventory_static.stat.exists
+    - inventory_dir is defined
+  ansible.builtin.file:
+    path: "{{ __tmp_add_inventory_file }}"
+    state: absent
+
+- name: Print updated inventory to log
+  ansible.builtin.debug:
+    msg: "{{ groups }}"
+    verbosity: 3

--- a/roles/dynamic_inventory/tasks/retire_static_inventory.yml
+++ b/roles/dynamic_inventory/tasks/retire_static_inventory.yml
@@ -1,4 +1,6 @@
-# Copyright 2022 Cloudera, Inc. All Rights Reserved.
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,9 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Amazon Web Services
+- name: Check for a Static Inventory file
+  stat:
+    path: "{{ init__dynamic_inventory_artefact }}"
+  register: __inventory_static
 
-awscli>=1.25.22
-boto>=2.49.0
-botocore>=1.27.22
-boto3>=1.24.22
+- name: Create a backup
+  when: __inventory_static.stat.exists
+  copy:
+    src: "{{ __inventory_static.stat.path }}"
+    dest: "{{ [init__dynamic_inventory_artefact | splitext | first, ansible_date_time.epoch] | join('.') }}"
+
+- name: Remove static inventory file
+  ansible.builtin.file:
+    path: "{{ init__dynamic_inventory_artefact }}"
+    state: absent

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -60,7 +60,7 @@ infra__dynamic_inventory_delete_storage: "{{ infra.dynamic_inventory.storage.del
 infra__teardown_deletes_data:       "{{ infra.teardown.delete_data | default(False) }}"
 infra__teardown_deletes_ssh_key:    "{{ infra.teardown.delete_ssh_key | default(False) }}"
 infra__teardown_deletes_network:    "{{ infra.teardown.delete_network | default(True) }}"
-infra__teardown_download_mirror:    "{{ infra.teardown.delete_mirror | default(False) }}"
+infra__teardown_auto_repo_mirror:    "{{ infra.teardown.delete_mirror | default(False) }}"
 
 infra__region:                      "{{ common__region }}"
 
@@ -158,8 +158,9 @@ infra__cdp_control_plane_ports:     "{{ env.cdp.control_plane.ports | default([4
 infra__cdp_control_plane_cidr:      "{{ env.cdp.control_plane.cidr | default(infra__cdp_control_plane_cidr_default) }}"
 
 # Utility Service for Download Mirror
-infra__create_utility_service:      "{{ globals.create_utility_service | default('no') | bool }}"
-infra__utlity_bucket_name:          "{{ globals.utility_bucket_name | default('') }}"
+infra__create_utility_service:        "{{ globals.create_utility_service | default('no') | bool }}"
+infra__utlity_bucket_name:            "{{ globals.utility_bucket_name | default('') }}"
+#infra__auto_repo_mirror_bucket_prefix: "{{ auto_repo_mirror_prefix | default('cache') }}"
 
 # Teardown
 infra__force_teardown:              "{{ common__force_teardown }}"

--- a/roles/infrastructure/tasks/initialize_aws.yml
+++ b/roles/infrastructure/tasks/initialize_aws.yml
@@ -180,16 +180,4 @@
   ansible.builtin.set_fact:
     infra__discovered_compute_inventory: "{{ __infra_dynamic_inventory_discovered.instances + __infra_utility_compute_discovered.instances }}"
 
-# Note that the download mirror is localised to the Account and Region deliberately
-- name: Determine Download Mirror Bucket Name
-  when:
-    - not infra__utlity_bucket_name
-    - infra__create_utility_service | bool
-  ansible.builtin.set_fact:
-    infra__utlity_bucket_name: "{{ [ infra__download_mirror_bucket_prefix, infra__aws_caller_info.account, infra__region ] | join('-') }}"
 
-# These need to be set as facts on the Ansible Controller to be picked up later
-- name: Set Download Mirror output artefacts
-  ansible.builtin.set_fact:
-    infra__type: "{{ infra__type }}"
-    infra__region: "{{ infra__region }}"

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -41,7 +41,7 @@
     network:
       assign_public_ip: yes
 
-- name: Ensure instances have Public IPs assigned
+- name: Ensure all {{ infra__dynamic_inventory_count }} instances have Public IPs assigned
   register: __infra_dynamic_inventory_instances
   amazon.aws.ec2_instance_info:
     region: "{{ infra__region }}"

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -71,7 +71,7 @@
     instance_type: "{{ infra__dynamic_inventory_vm_type_default[infra__type]['sml'] }}"
     image_id: "{{ __infra_aws_ami_info.image_id }}"
     ebs_optimized: yes
-    instance_role: "{{ infra__download_mirror_role.iam_role.role_name }}"
+    instance_role: "{{ infra__auto_repo_mirror_role.iam_role.role_name }}"
     volumes:
       - device_name: /dev/sda1
         ebs:

--- a/roles/infrastructure/tasks/setup_aws_utility_service.yml
+++ b/roles/infrastructure/tasks/setup_aws_utility_service.yml
@@ -63,7 +63,7 @@
   failed_when: __infra_aws_utility_bucket_policy_tags.rc != 0
 
 - name: Create Role to access Storage Utility Service Bucket
-  register: infra__download_mirror_role
+  register: infra__auto_repo_mirror_role
   community.aws.iam_role:
     create_instance_profile: yes
     name: "{{ infra__utlity_bucket_name }}"

--- a/roles/infrastructure/tasks/teardown_aws_storage.yml
+++ b/roles/infrastructure/tasks/teardown_aws_storage.yml
@@ -25,7 +25,7 @@
   loop: "{{ infra__aws_storage_locations }}"
 
 - name: Remove AWS Storage Utility Bucket
-  when: infra__teardown_download_mirror | bool
+  when: infra__teardown_auto_repo_mirror | bool
   amazon.aws.aws_s3:
     region: "{{ infra__region }}"
     bucket: "{{ infra__utlity_bucket_name }}"

--- a/roles/init_deployment/defaults/main.yml
+++ b/roles/init_deployment/defaults/main.yml
@@ -1,0 +1,52 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default Paths
+default_local_temp_dir: '/tmp'
+default_sshkey_path: '~/.ssh'
+default_config_path: '~/.config/cloudera-deploy'
+
+# Default names
+default_name_prefix: cldr
+default_ssh_key_suffix: _ssh_rsa
+
+# Default Basic Cluster Config
+default_cluster_definition_file: "vars/basic_cluster.yml"
+
+# Default Artefact Filenames
+default_profile_path: "{{ [default_config_path, 'profiles'] | path_join }}"
+default_profile_file: "default"
+default_definition_file: "definition.yml"
+default_cluster_file: "cluster.yml"
+default_pre_setup_tasklist: "pre_setup.yml"
+default_post_setup_tasklist: "post_setup.yml"
+default_pre_teardown_tasklist: "pre_teardown.yml"
+default_post_teardown_tasklist: "post_teardown.yml"
+
+include_inventory_file: ''
+auto_repo_mirror_file: "{{ [default_config_path, 'auto_repo_mirror.ini'] | path_join }}"
+
+# Default behavior
+use_default_cluster_definition: no
+
+# Default Deployment Controls
+default_infra_deployment_engine: ansible
+default_infra_type: aws  # azure, gcp
+default_infra_region: us-east-1  # westeurope, gcp?
+default_parcel_distro: el7  # el8, bionic, focal
+
+# Terraform defaults
+default_terraform_base_dir: "{{ [default_config_path, 'terraform'] | path_join }}" 

--- a/roles/init_deployment/tasks/main.yml
+++ b/roles/init_deployment/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Check versions
+- name: Get Python packages
+  register: __python_env_packages
+  command: pip freeze
+
+- name: Get Ansible Collections
+  register: __ansible_collection_list
+  command: ansible-galaxy collection list
+
+- name: Get Ansible Roles
+  register: __ansible_role_list
+  command: ansible-galaxy role list
+
+- name: Log Runtime information
+  ansible.builtin.debug:
+    msg:
+      - "Ansible Version: {{ ansible_version | to_yaml }}"
+      - "Ansible Collections: {{ __ansible_collection_list.stdout | to_nice_yaml }}"
+      - "Ansible Roles: {{ __ansible_role_list.stdout }}"
+      - "Python Version: {{ ansible_python_version }}"
+      - "Python Packages: {{ __python_env_packages.stdout }}"
+      - "Runner Version: '{{ lookup('env', 'CLDR_BUILD_VER') }}'"
+    verbosity: 1
+
+- name: Marshall Deployment Definition
+  ansible.builtin.include_tasks: marshall.yml
+
+- name: Handle SSH Keys Setup
+  ansible.builtin.include_tasks: ssh.yml
+
+- name: Establish RunLevels and Sequence
+  ansible.builtin.include_tasks: runlevels.yml
+
+# Runs last so we know what kind of run we're doing, and what facts to validate
+- name: Validate Deployment Definition
+  ansible.builtin.include_tasks: validate.yml
+
+- name: Explicitly finalise Initialisation to avoid duplicate init
+  ansible.builtin.set_fact:
+    init__completed: True

--- a/roles/init_deployment/tasks/marshall.yml
+++ b/roles/init_deployment/tasks/marshall.yml
@@ -1,0 +1,215 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Check path
+- name: Check a Definition path has been supplied
+  ansible.builtin.assert:
+    quiet: yes
+    that:
+      - definition_path is defined
+      - definition_path | length > 0
+    fail_msg: "You must supply a 'definition_path' pointing to your artefacts directory"
+
+- name: Check if Definition Path '{{ definition_path }}' exists
+  ansible.builtin.stat:
+    path: "{{ definition_path }}"
+  register: __definition_path_stat
+
+- name: Assert Definition Path is a directory
+  ansible.builtin.assert:
+    quiet: yes
+    fail_msg: "'definition_path' does not appear to point to an existing and reachable directory'"
+    that:
+      - __definition_path_stat.stat.isdir is defined
+      - __definition_path_stat.stat.isdir
+
+# Set File Paths
+- name: Set Expected File Paths
+  ansible.builtin.set_fact:
+    init__user_profile: "{{ abs_profile | default([profile_path | default(default_profile_path), profile | default(default_profile_file)] | path_join ) }}"
+    init__definition_file: "{{ abs_definition | default( [definition_path, definition_file | default(default_definition_file)] | path_join ) }}"
+    init__cluster_file: "{{ abs_cluster | default( [definition_path, cluster_file | default(default_cluster_file)] | path_join ) }}"
+    init__auto_repo_mirror_artefact: "{{ auto_repo_mirror_file | default(auto_repo_mirror_file) }}"
+    init__pre_setup_tasklist: "{{ abs_pre_setup | default( [definition_path, pre_setup_tasklist | default(default_pre_setup_tasklist)] | path_join ) }}"
+    init__post_setup_tasklist: "{{ abs_post_setup | default( [definition_path, post_setup_tasklist | default(default_post_setup_tasklist)] | path_join ) }}"
+    init__pre_teardown_tasklist: "{{ abs_pre_teardown | default( [definition_path, pre_teardown_tasklist | default(default_pre_teardown_tasklist)] | path_join ) }}"
+    init__post_teardown_tasklist: "{{ abs_post_teardown | default( [definition_path, post_teardown_tasklist | default(default_post_teardown_tasklist)] | path_join ) }}"
+
+# Handle User Config
+- name: Check for User Config file
+  register: __user_config_stat
+  ansible.builtin.stat:
+    path: "{{ init__user_profile }}"
+
+- name: Load User Config
+  when: __user_config_stat.stat.exists
+  ansible.builtin.include_vars:
+    file: "{{ __user_config_stat.stat.path }}"
+
+# Handle Definition File
+- name: Seek Definition files in Definition Path
+  register: __def_file_stat
+  ansible.builtin.stat:
+    path: "{{ init__definition_file }}"
+
+- name: Assert that a Definition File has been provided
+  ansible.builtin.assert:
+    quiet: yes
+    that: __def_file_stat.stat.exists
+    fail_msg: "Expected to find a definition file '{{ init__definition_file }}' in Definition Path '{{ definition_path }}'"
+
+# User Definition files may contain lazy templating which would break if pre-merged here, therefore the cluster defaults file is kept separate
+- name: Select default provided User Definition Files
+  ansible.builtin.set_fact:
+    init__user_definition_file: "{{ __def_file_stat.stat.path }}"
+    init__cluster_definition_file: "{{ __def_file_stat.stat.path }}"
+
+# Handle separate Cluster File
+- name: Seek Cluster Definition files in Definition Path
+  register: __clus_file_stat
+  ansible.builtin.stat:
+    path: "{{ init__cluster_file }}"
+
+- name: Include vars to top level for other facts in Definition File
+  ansible.builtin.include_vars:
+    file: "{{ init__user_definition_file }}"
+
+# Must be included before cluster definition checks as it may have logic control switches
+- name: Override with separate Cluster file if provided
+  when: __clus_file_stat.stat.exists
+  ansible.builtin.set_fact:
+    init__cluster_definition_file: "{{ __clus_file_stat.stat.path }}"
+
+# Override with default cluster definition if requested, regardless of files found
+- name: Use default cluster definition as override if requested
+  when: use_default_cluster_definition | bool
+  block:
+    - name: Copy basic cluster definition to tmp
+      copy:
+        src: "{{ default_cluster_definition_file }}"
+        dest: /tmp/basic_cluster.yml
+
+    - name: Set basic definition as target definition
+      ansible.builtin.set_fact:
+        init__cluster_definition_file: /tmp/basic_cluster.yml
+
+- name: Include vars from User Definition File to private dict to check for Globals
+  ansible.builtin.include_vars:
+    file: "{{ init__user_definition_file }}"
+    name: __def_vars
+
+# Note that this depends on the earlier set_fact for globals to take precedence over include_vars
+- name: Include Cluster definition file for current localhost use after User Definition is Loaded
+  ansible.builtin.include_vars:
+    file: "{{ init__cluster_definition_file }}"
+
+
+# Admin Password
+- name: Prompt User for a password if not provided in config or vault
+  when: admin_password is undefined or admin_password | length < 2
+  block:
+    - name: Prompt User for Password if not supplied
+      no_log: true
+      pause:
+        prompt: "No admin password found in profile.yml or extra_vars, or provided password too short; please provide a Password"
+      register: __user_input_password
+
+    - name: Set Admin password
+      no_log: true
+      ansible.builtin.set_fact:
+        admin_password: "{{ __user_input_password.user_input }}"
+
+# Parcel Distro
+- name: Determine preferred Parcel Distribution
+  ansible.builtin.set_fact:
+    init__parcel_distro: "{{ parcel_distro | default(default_parcel_distro) }}"
+
+# Merge User Profile to Globals
+- name: Marshal User Config into Globals
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine(user_config , recursive=True) }}"
+  vars:
+    user_config:
+      name_prefix: "{{ name_prefix | default(default_name_prefix) }}"
+      tags: "{{ tags | default(omit) }}"
+      region: "{{ infra_region | default(default_infra_region) }}"
+      infra_deployment_engine: "{{ infra_deployment_engine | default(default_infra_deployment_engine) }}"
+      infra_type: "{{ infra_type | default(default_infra_type) }}"
+      terraform:
+        base_dir: "{{ terraform.base_dir | default(default_terraform_base_dir) | expanduser }}"
+        state_storage: "{{ terraform.state_storage | default(omit) }}"
+        auto_remote_state: "{{ terraform.auto_remote_state | default(False) }}"
+        remote_state_bucket: "{{ terraform.remote_state_bucket | default(omit) }}"
+        remote_state_lock_table: "{{ terraform.remote_state_lock_table | default(omit) }}"
+      ssh:
+        public_key_id: "{{ public_key_id | default(omit) }}"
+        public_key_file: "{{ public_key_file | default(omit) }}"
+        public_key_text: "{{ public_key_text | default(omit) }}"
+        private_key_file: "{{ private_key_file | default(omit) }}"
+        key_path: "{{ ssh_key_path | default(default_sshkey_path) }}"
+      cloudera_license_file: "{{ license_file | default(omit) }}"
+      gcloud_credential_file: "{{ gcloud_credential_file | default(omit) }}"
+      cdp_profile: "{{ cdp_profile | default(omit) }}"
+      cdp_region: "{{ cdp_region | default(omit) }}"
+      aws_profile: "{{ aws_profile | default(omit) }}"
+      force_teardown: "{{ purge | default(omit) }}"
+      env_vars: "{{ env_vars | default(omit) }}"
+
+- name: Set GCloud Environment Variables if needed
+  when: globals.gcloud_credential_file is defined
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine( env_gcp_entries, recursive=True ) }}"
+  vars:
+    env_gcp_entries:
+      env_vars:
+        GCP_AUTH_KIND: serviceaccount
+        GCP_SERVICE_ACCOUNT_FILE: "{{ globals.gcloud_credential_file }}"
+
+- name: Add no_log variables to globals
+  no_log: true
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine(__no_log_globals, recursive=True) }}"
+  vars:
+    __no_log_globals:
+      admin_password: "{{ admin_password | mandatory }}"
+
+- name: Set CM facts
+  ansible.builtin.set_fact:
+    cloudera_manager_license_file: "{{ globals.cloudera_license_file | default(omit) }}"
+    cloudera_manager_admin_password: "{{ globals.admin_password }}"
+  no_log: true
+
+# Ansible tempfile doesn't appear to work well on ansible-runner
+- name: Set local Temp directory if not supplied
+  ansible.builtin.set_fact:
+    local_temp_dir: "{{ local_temp_dir | default(default_local_temp_dir) }}"
+
+- name: Set Profile Env Vars if required
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine( env_var_entries, recursive=True ) }}"
+  vars:
+    env_var_entries:
+      env_vars:
+        CDP_PROFILE: "{{ globals.cdp_profile | default(omit) }}"
+        AWS_PROFILE: "{{ globals.aws_profile | default(omit) }}"
+        AWS_REGION: "{{ globals.region | default(omit) }}"
+
+# This task is last to allow hard-coded 'globals' in the definition.yml to take top priority as a break-glass measure
+- name: Merge overwrite globals from Definition file with Globals on User File
+  when: __def_vars.globals is defined
+  ansible.builtin.set_fact:
+    globals: "{{ globals | combine(__def_vars.globals, recursive=True) }}"

--- a/roles/init_deployment/tasks/prep_pvc.yml
+++ b/roles/init_deployment/tasks/prep_pvc.yml
@@ -1,0 +1,69 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Set specific Facts for later use in Cluster Deployment
+  ansible.builtin.set_fact:
+    _pre_template_cluster: "{{ lookup('file', init__cluster_definition_file ) | from_yaml }}"
+    preload_parcels: "{{ auto_repo_mirror_file_list | default([]) }}"
+    custom_repo_rehost_files: "{{ auto_repo_mirror_file_list | default([]) }}"
+  delegate_to: "{{ __play_host }}"
+  delegate_facts: true
+  loop: "{{ groups.all }}"
+  loop_control:
+    loop_var: __play_host
+    label: __play_host
+
+- name: Set Sensitive Facts with no-log for later use in Cluster Deployment
+  ansible.builtin.set_fact:
+    cloudera_manager_admin_password: "{{ globals.admin_password }}"
+    cloudera_manager_license_file: "{{ globals.cloudera_license_file | default(omit) }}"
+  delegate_to: "{{ __play_host }}"
+  delegate_facts: true
+  no_log: true
+  loop: "{{ groups.all }}"
+  loop_control:
+    loop_var: __play_host
+    label: __play_host
+
+- name: Include Definition Vars to allow overrides to propagate to Cluster Deployment
+  ansible.builtin.include_vars:
+    file: "{{ init__user_definition_file }}"
+  delegate_to: "{{ __play_host }}"
+  delegate_facts: true
+  loop: "{{ groups.all }}"
+  loop_control:
+    loop_var: __play_host
+    label : __play_host
+
+- name: Include Cluster Definition override
+  ansible.builtin.include_vars:
+    file: "{{ init__cluster_definition_file }}"
+  delegate_to: "{{ __play_host }}"
+  delegate_facts: true
+  loop: "{{ groups.all }}"
+  loop_control:
+    loop_var: __play_host
+    label : __play_host
+
+- name: Create local temp directories
+  file: "{{ __dir }}"
+  loop:
+    - path: "{{ local_temp_dir }}/csrs"
+      state: directory
+    - path: "{{ local_temp_dir }}/certs"
+      state: directory
+  loop_control:
+    loop_var: __dir

--- a/roles/init_deployment/tasks/runlevels.yml
+++ b/roles/init_deployment/tasks/runlevels.yml
@@ -1,0 +1,28 @@
+---
+
+# Copyright 2022 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Configure runlevel tags
+  ansible.builtin.set_fact:
+    run_teardown: "{{ 'teardown' in ansible_run_tags }}"
+    run_infrastructure: "{{ 'infra' in ansible_run_tags }}"
+    run_platform: "{{ 'plat' in ansible_run_tags }}"
+    run_pvc: "{{ 'pvc' in ansible_run_tags }}"
+    run_runtime: "{{ ansible_run_tags | difference(['infra', 'plat', 'teardown']) | length > 0 }}"
+
+- name: Determine if Specific Roles should be called
+  ansible.builtin.set_fact:
+    init__call_cdp_pvc: "{{ mgmt is defined or cluster is defined }}"
+    init__call_cdp_pbc: "{{ env is defined or ml is defined or de is defined or datahub is defined or opdb is defined or dw is defined or df is defined | default(False) }}"

--- a/roles/init_deployment/tasks/ssh.yml
+++ b/roles/init_deployment/tasks/ssh.yml
@@ -1,0 +1,75 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Use default SSH public key id
+  when: globals.ssh.public_key_id is undefined
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine(__default_ssh_key_id, recursive=True) }}"
+  vars:
+    __default_ssh_key_id:
+      ssh:
+        public_key_id: "{{ globals.name_prefix }}"
+
+- name: Generate SSH public and private keys
+  when: (globals.ssh.public_key_file is undefined or globals.ssh.public_key_file | length < 3) and globals.ssh.public_key_text is undefined
+  block:
+    - name: Generate a SSH keypair (public and private keys)
+      register: __generated_ssh_keys
+      community.crypto.openssh_keypair:
+        path: "{{ [default_sshkey_path, __generated_keypair_name] | path_join }}"
+        comment: "{{ globals.name_prefix }} (auto-generated)"
+        type: rsa
+        size: 4096
+        regenerate: never
+        force: no
+      vars:
+        __generated_keypair_name: "{{ globals.name_prefix + default_ssh_key_suffix }}"
+
+    - name: Set facts for the generated SSH keypair details
+      ansible.builtin.set_fact:
+        globals: "{{ globals | default({}) | combine(__generated_keypair, recursive=True) }}"
+      vars:
+        __generated_keypair:
+          ssh:
+            private_key_file: "{{ __generated_ssh_keys.filename }}"
+            public_key_file: "{{ [ __generated_ssh_keys.filename, 'pub' ] | join('.') }}"
+
+- name: Load SSH public key file to text
+  when: globals.ssh.public_key_file is defined
+  ansible.builtin.set_fact:
+    globals: "{{ globals | default({}) | combine(__public_key_globals , recursive=True) }}"
+  vars:
+    __public_key_globals:
+      ssh:
+        public_key_text: "{{ lookup('file', globals.ssh.public_key_file ) | default(omit) }}"
+
+- name: Validate SSH Private Key File has acceptable permissions
+  when: globals.ssh.private_key_file is defined
+  block:
+    - name: Get information for SSH Private Key File
+      ansible.builtin.stat:
+        path: "{{ globals.ssh.private_key_file }}"
+      register: __private_key_file_stat
+
+    - name: Assert that SSH Private Key has valid permissions
+      ansible.builtin.assert:
+        that:
+          - __private_key_file_stat.stat.mode == '0400' or __private_key_file_stat.stat.mode == '0600'
+        fail_msg:
+          - "SSH Private Key at {{ __private_key_file_stat.stat.path }} has invalid permissions"
+          - "Permissions are {{ __private_key_file_stat.stat.mode }}"
+          - "Permissions should be 0400 or 0600"
+        quiet: yes

--- a/roles/init_deployment/tasks/validate.yml
+++ b/roles/init_deployment/tasks/validate.yml
@@ -1,0 +1,91 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: If Purge is defined, check it is boolean
+  when: purge is defined
+  ansible.builtin.assert:
+    that: purge|bool is sameas true or purge|bool is sameas false
+    fail_msg: "purge key is present in definition, but not a boolean as expected"
+    quiet: yes
+
+- name: Assert user has supplied an Admin Password
+  no_log: true
+  ansible.builtin.assert:
+    quiet: yes
+    that:
+      - admin_password is defined
+      - admin_password | length > 2
+    fail_msg: "You must supply an Admin Password of at least 2 chars"
+
+# Validate Name Prefix
+- name: Check supplied Namespace (Azure)
+  when:
+    - globals.infra_type == 'azure'
+    - "'teardown' not in {{ ansible_run_tags }}"
+  ansible.builtin.assert:
+    that:
+      - globals.name_prefix | length > 1
+      - globals.name_prefix | length < 5
+      - globals.name_prefix | regex_search('^[a-zA-Z]')
+    fail_msg: "You must supply a valid Namespace"
+    quiet: yes
+
+- name: Check supplied Namespace
+  when:
+    - globals.infra_type != 'azure'
+    - "'teardown' not in ansible_run_tags"
+  ansible.builtin.assert:
+    that:
+      - globals.name_prefix | length > 1
+      - globals.name_prefix | length < 8
+      - globals.name_prefix | regex_search('^[a-zA-Z]')
+    fail_msg: "You must supply a valid Namespace"
+    quiet: yes
+
+- name: Check Deployment Engine variable
+  ansible.builtin.assert:
+    that:
+      - globals.infra_deployment_engine in ['ansible', 'terraform']
+    fail_msg: "The 'infra_deployment_engine' variable must be one of 'ansible', 'terraform'"
+    quiet: yes
+
+- name: Check Supplied terraform_base_dir variable
+  when:
+    - globals.infra_deployment_engine == 'terraform'
+  ansible.builtin.assert:
+    that:
+      - globals.terraform.base_dir is defined
+      - globals.terraform.base_dir | length > 0
+    fail_msg: "You must supply a 'terraform_base_dir' where Terraform assets will be placed"
+    quiet: yes
+
+- name: Check Supplied terraform_auto_remote_state variable
+  when:
+    - globals.infra_deployment_engine == 'terraform'
+  ansible.builtin.assert:
+    that:
+      - (globals.terraform.auto_remote_state|bool is sameas true) or (globals.terraform.auto_remote_state|bool is sameas false)
+    fail_msg: "The terraform.auto_remote_state variable must be a boolean variable"
+    quiet: yes
+
+- name: Check Admin Password is CDP Cloud compliant
+  when: init__call_cdp_pbc | bool
+  ansible.builtin.assert:
+    that:
+      - admin_password is match('^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,64}$')
+    fail_msg: >-
+      Admin Password must comply with CDP Public requirements: 1 Upper, 1 Special, 1 Number, 8-64 chars.
+    quiet: yes

--- a/roles/init_deployment/vars/basic_cluster.yml
+++ b/roles/init_deployment/vars/basic_cluster.yml
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cloudera_manager_version: 7.6.5
-
 clusters:
   - name: Basic Cluster
     services: [HDFS, YARN, ZOOKEEPER]

--- a/roles/init_deployment/vars/basic_cluster.yml
+++ b/roles/init_deployment/vars/basic_cluster.yml
@@ -1,0 +1,68 @@
+---
+
+# Copyright 2021 Cloudera, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cloudera_manager_version: 7.6.5
+
+clusters:
+  - name: Basic Cluster
+    services: [HDFS, YARN, ZOOKEEPER]
+    repositories:
+      - https://archive.cloudera.com/cdh7/7.1.7.0/parcels/
+    configs:
+      HDFS:
+        DATANODE:
+          dfs_data_dir_list: /dfs/dn
+        NAMENODE:
+          dfs_name_dir_list: /dfs/nn
+        SECONDARYNAMENODE:
+          fs_checkpoint_dir_list: /dfs/snn
+      YARN:
+        RESOURCEMANAGER:
+          yarn_scheduler_maximum_allocation_mb: 4096
+          yarn_scheduler_maximum_allocation_vcores: 4
+        NODEMANAGER:
+          yarn_nodemanager_resource_memory_mb: 4096
+          yarn_nodemanager_resource_cpu_vcores: 4
+          yarn_nodemanager_local_dirs:  /tmp/nm
+          yarn_nodemanager_log_dirs: /var/log/nm
+        GATEWAY:
+          mapred_submit_replication: 3
+          mapred_reduce_tasks: 6
+      ZOOKEEPER:
+        SERVICEWIDE:
+          zookeeper_datadir_autocreate: true
+    host_templates:
+      Master1:
+        HDFS: [NAMENODE, SECONDARYNAMENODE]
+        YARN: [RESOURCEMANAGER, JOBHISTORY]
+        ZOOKEEPER: [SERVER]
+      Workers:
+        HDFS: [DATANODE]
+        YARN: [NODEMANAGER]
+
+mgmt:
+  name: Cloudera Management Service
+  services: [ALERTPUBLISHER, EVENTSERVER, HOSTMONITOR, REPORTSMANAGER, SERVICEMONITOR]
+
+hosts:
+  configs:
+    host_default_proc_memswap_thresholds:
+      warning: never
+      critical: never
+    host_memswap_thresholds:
+      warning: never
+      critical: never
+    host_config_suppression_agent_system_user_group_validator: true

--- a/roles/platform/tasks/initialize_setup_aws.yml
+++ b/roles/platform/tasks/initialize_setup_aws.yml
@@ -154,7 +154,9 @@
       register: __aws_security_group_knox_info
 
     - name: Set fact for AWS Security Group ID for Knox
-      when: __aws_security_group_knox_info is defined
+      when:
+        - __aws_security_group_knox_info is defined
+        - __aws_security_group_knox_info.security_groups | length > 0
       ansible.builtin.set_fact:
         plat__aws_security_group_knox_id: "{{ __aws_security_group_knox_info.security_groups[0].group_id }}"
 


### PR DESCRIPTION
Updated requirements for gcp, azure, and aws to pin requirements more suitable for Ansible 2.12. Needs full test runs to validate.
Migrated download_mirror from cloudera-deploy, renamed to auto_repo_mirror to better reflect actual functionality. Updated tasks to be more streamlined when used in a Collection. More refactoring to do here.
Migrated dynamic_inventory from cloudera-deploy, renamed some tasklists to better explain functionality. Needs further work to support different machine types from inventory template.
Updated cloudera.exe.infrastructure to support changes in dynamic_inventory. More to do to extract it as separate capability, espectially from utility_vm
Cloudera-Deploy init migrated to init_deployment. Now available to init any run against a definition_path for users not leveraging cloudera-deploy. woop woop.
minor bugfix where a know security group is not already present on a vpc when cloudera.exe.platform is called.

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>