### PR TITLE
Change lookup search for Azure Service Principal Object ID

### DIFF
--- a/roles/platform/tasks/initialize_azure.yml
+++ b/roles/platform/tasks/initialize_azure.yml
@@ -73,7 +73,7 @@
 
     - name: Set Service Principal Object UUID for Azure App
       ansible.builtin.set_fact:
-        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
+        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].id') }}"
 
     - name: Check that Azure Service Principal ID is now set
       ansible.builtin.assert:

--- a/roles/platform/tasks/setup_azure_authz.yml
+++ b/roles/platform/tasks/setup_azure_authz.yml
@@ -89,7 +89,7 @@
 
     - name: Set Service Principal Object ID for new Azure App
       ansible.builtin.set_fact:
-        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].objectId') }}"
+        plat__azure_application_service_principal_objuuid: "{{ __azure_application_service_principals_list.stdout | from_json | community.general.json_query('[0].id') }}"
 
     - name: Check that Azure Service Principal ID is now set
       ansible.builtin.assert:


### PR DESCRIPTION
cldr-runner image v1.7.0 has updated the Azure CLI to version `2.38.0` (in cldr-runner v1.6.4 azure-cli was 2.36.0).

In this version of Azure CLI the output field names from `az ad sp list` have changed. In particular the `objectId` field has changed to `id`. This PRs changes tasks in the platform that search for the Service Principal Object UUID to be the updated field.

For testing with this change I've confirmed that CDP Azure environment setup and teardown works correctly when using the latest cldr-runner image.

Signed-off-by: Jim Enright <jenright@cloudera.com>