### PR TITLE
Fixes for RHEL8.6 support and Dynamic Inventory

### DIFF
--- a/roles/auto_repo_mirror/tasks/inject.yml
+++ b/roles/auto_repo_mirror/tasks/inject.yml
@@ -97,6 +97,16 @@
           | select('search', init__parcel_distro)
           | list }}"
 
+    - name: Include Cloudera Manager Tarball
+      ansible.builtin.set_fact:
+        init__urls_to_sign: "{{ init__urls_to_sign
+            | default([]) + __auto_repo_mirror_ini_entry
+            | select('search', 'repo-as-tarball')
+            | select('search', cloudera_manager_version)
+            | select('search', cm_distro_select[init__parcel_distro]['version'] | string + '.tar')
+            | list }}"
+
+# TODO: Filter to relevent version manifests, not all manifests, just to be tidy
     - name: Ensure manifest is included in Download Mirror URLs if present
       loop: "{{ init__cluster_repo_entries }}"
       loop_control:

--- a/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
+++ b/roles/auto_repo_mirror/tasks/parse_definition_for_mirror_targets.yml
@@ -56,7 +56,7 @@
   loop_control:
     loop_var: __filtered_parcel_item
   ansible.builtin.set_fact:
-    init__file_mirror_targets: "{{ init__file_mirror_targets | default(__init_tarball_links) + [__filtered_parcel_item, __filtered_parcel_item + '.sha1', __filtered_parcel_item + '.sha', __filtered_parcel_item.replace(__filtered_parcel_item | basename, 'manifest.json') ] }}"
+    init__file_mirror_targets: "{{ init__file_mirror_targets | default(__init_tarball_links) + [__filtered_parcel_item, __filtered_parcel_item + '.sha1', __filtered_parcel_item + '.sha', __filtered_parcel_item + '.sha256', __filtered_parcel_item.replace(__filtered_parcel_item | basename, 'manifest.json') ] }}"
 
 # Explicitly set version from parcel distro as Ansible controller could be different OS from target cluster
 - name: Determine Cloudera-Manager Distro and Version
@@ -120,4 +120,4 @@
     __auto_repo_mirror_spec:
       auto_repo_mirror_targets: "{{ init__file_mirror_targets }}"
       utility_bucket_name: "{{ init__auto_repo_mirror_bucket_name }}"
-      create_utility_service: init__file_mirror_targets | length > 0 | bool
+      create_utility_service: "{{ init__file_mirror_targets | length > 0 | bool }}"

--- a/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
+++ b/roles/auto_repo_mirror/tasks/populate_from_upstream.yml
@@ -68,6 +68,7 @@
   block:
     # Prepare to sync cache dir to S3
     - name: Setup System Rhel8
+      ignore_errors: true  # newer versions of rhel8 do not need or have epel-release
       when:
         - ansible_os_family == 'RedHat'
         - ansible_distribution_major_version | int >= 8

--- a/roles/infrastructure/tasks/setup.yml
+++ b/roles/infrastructure/tasks/setup.yml
@@ -33,7 +33,6 @@
     ansible.builtin.include_tasks: "setup_{{ infra__type | lower }}_utility_service.yml"
 
   - name: Set up provider-specific Infrastructure Compute
-    when: infra__dynamic_inventory_count
     ansible.builtin.include_tasks: "setup_{{ infra__type | lower }}_compute.yml"
 
 - name: Set up for Terraform deployment engine

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# You must have subscribed to Centos in the AWS Marketplace: https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce
+# You must have subscribed to the target OS in the AWS Marketplace, e.g. Centos https://aws.amazon.com/marketplace/pp?sku=aw0evgkw8e5c1q413zgy5pjce
 
 - name: Ensure required number of Dynamic Inventory VMs are deployed and tagged correctly during deployment
   loop_control:

--- a/roles/infrastructure/tasks/setup_aws_compute.yml
+++ b/roles/infrastructure/tasks/setup_aws_compute.yml
@@ -40,6 +40,7 @@
     vpc_subnet_id: "{{ infra__aws_subnet_ids | first }}"
     network:
       assign_public_ip: yes
+      delete_on_termination: yes
 
 - name: Ensure all {{ infra__dynamic_inventory_count }} instances have Public IPs assigned
   register: __infra_dynamic_inventory_instances

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -34,7 +34,7 @@ infra__dynamic_inventory_images_default:
       owners:
         - 'aws-marketplace'
     el8:
-      search: 'RHEL-8.4*HVM*x86_64*'
+      search: 'RHEL-8.6*HVM-*x86_64*'
       user: 'ec2-user'
       owners:
         - '309956199498'


### PR DESCRIPTION
Include Cloudera-Manager repo-as-tarball by default when collecting list of files for mirroring to custom_repo
Include newer .sha256 checksums in custom_repo auto mirroring Fix bug where utility server was always being created for dynamic inventory because of typo in repo mirror targets test Newer versions of RHEL8 do not need epel-release to install python3, skipping when not necessary Switched dynamic inventory to use RHEL8.6 instead of RHEL8.4 to keep up with preferred LTS releases

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>