### PR TITLE
Fix Azure deployment

### DIFF
--- a/roles/platform/tasks/setup_azure_authz.yml
+++ b/roles/platform/tasks/setup_azure_authz.yml
@@ -201,6 +201,11 @@
       scope: "{{ plat__azure_datapath_uri }}"
       assignee: "{{ __azure_ranger_audit_identity.properties.principalId }}"
       desc: Assign Storage Blob Data Contributor Role to Ranger Audit Role at Data Container level
+    - role: "{{ __azure_storageblobdata_ctrb_role_id }}"
+      scope: "{{ plat__azure_logpath_uri }}"
+      assignee: "{{ __azure_ranger_audit_identity.properties.principalId }}"      
+      desc: Assign Storage Blob Data Contributor Role to Ranger Audit Role at Logs Container level
+
   loop_control:
     loop_var: __azure_rl_assgn_item
     label: "{{ __azure_rl_assgn_item.desc }}"

--- a/roles/platform/tasks/teardown_azure_authz.yml
+++ b/roles/platform/tasks/teardown_azure_authz.yml
@@ -74,8 +74,8 @@
 - name: Tear down Azure AD App Registration
   when: plat__teardown_deletes_xaccount and ( plat__azure_xaccount_app_uuid is defined ) and ( plat__azure_xaccount_app_uuid | length > 0 )
   command: >
-      az ad sp delete
-      --id {{ plat__azure_application_service_principal_objuuid }}
+      az ad app delete
+      --id {{ plat__azure_xaccount_app_uuid }}
 
 - name: Tear down Custom Role
   when: plat__teardown_deletes_roles


### PR DESCRIPTION
This PR fixes two minor issues to fix (re-)deployment of CDP Public Cloud on Azure.
* Added role assignment for the Azure Ranger Audit role following a CDP change of the required permissions on the MSI. This fixes #126.
* During teardown change deletion of the AD app from just deletion of the Service Principal to deletion of the full Application. It seems an update of the az cli means that delete of the SP doesn't delete the App.

Tested these changes by deploying an Azure-based environment, then ran a full teardown and then redeployed. All worked successfully.