### PR TITLE
Improve GCP APIs Services check and Enable

### DIFF
--- a/roles/platform/tasks/initialize_setup_gcp.yml
+++ b/roles/platform/tasks/initialize_setup_gcp.yml
@@ -15,14 +15,22 @@
 # limitations under the License.
 
 # https://docs.cloudera.com/management-console/cloud/requirements-gcp/topics/mc-gcp_apis.html
-- name: Ensure Google Services Enabled
+- name: Fetch listing of Enabled GCP Service APIs
   command: >
-    gcloud services enable
-    compute.googleapis.com
-    runtimeconfig.googleapis.com
-    iam.googleapis.com
-    iamcredentials.googleapis.com
-    storage.googleapis.com
-    servicenetworking.googleapis.com
-    sqladmin.googleapis.com
-    --quiet
+    gcloud services list --enabled --project {{ plat__gcp_project }}
+  register: __gcp_services_info
+
+- name: Determine list of missing APIs
+  set_fact:
+    __plat_gcp_services_to_enable: "{{ __plat_gcp_services_to_enable | default([]) + ([__gcp_service_item] if __gcp_service_item not in __gcp_services_info.stdout else []) | unique }}"
+  loop: "{{ plat__gcp_required_services }}"
+  loop_control:
+    loop_var: __gcp_service_item
+
+- name: Enable missing GCP Service APIs
+  when: __plat_gcp_services_to_enable | length > 0
+  command: >
+    gcloud services enable --quiet {{ __gcp_enable_item }}
+  loop: "{{ __plat_gcp_services_to_enable }}"
+  loop_control:
+    loop_var: __gcp_enable_item

--- a/roles/platform/vars/main.yml
+++ b/roles/platform/vars/main.yml
@@ -86,3 +86,13 @@ plat__azure_roles:
   storcnt: 'Storage Blob Data Contributor'
   contrib: 'Contributor'
   owner: 'Owner'
+
+
+plat__gcp_required_services:
+  - compute.googleapis.com
+  - runtimeconfig.googleapis.com
+  - iam.googleapis.com
+  - iamcredentials.googleapis.com
+  - storage.googleapis.com
+  - servicenetworking.googleapis.com
+  - sqladmin.googleapis.com


### PR DESCRIPTION
Move list of required GCP APIs into vars
Fetch listing of enabled services and check against required, only request new services to enable if necessary to avoid error where user lacks authorization to call the enable command

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>