### PR TITLE
Allow skipping of GCP Service and IAM management

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -197,6 +197,8 @@ env:
     version:
     scale:
   gcp:
+    auto_enable_services:
+    manage_identities:
     bindings:
       cross_account:
       logs:

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -169,6 +169,9 @@ plat__gcp_storage_location_logs:              "{{ env.gcp.storage.path.logs | de
 plat__gcp_xaccount_policy_bindings:           "{{ env.gcp.bindings.cross_account | default(plat__gcp_xaccount_policy_bindings_default) }}"
 plat__gcp_log_role_perms:                     "{{ env.gcp.bindings.logs | default(plat__gcp_log_policy_bindings_default) }}"
 
+plat__gcp_manage_identities:                  "{{ env.gcp.manage_identities | default(true) }}"
+plat__gcp_enable_services:                    "{{ env.gcp.auto_enable_services | default(true) }}"
+
 # Azure
 plat__azure_app_suffix:                       "{{ env.azure.app.suffix | default(common__app_suffix) }}"
 plat__azure_role_suffix:                      "{{ env.azure.role.suffix | default(common__role_suffix) }}"

--- a/roles/platform/tasks/initialize_setup_gcp.yml
+++ b/roles/platform/tasks/initialize_setup_gcp.yml
@@ -15,22 +15,25 @@
 # limitations under the License.
 
 # https://docs.cloudera.com/management-console/cloud/requirements-gcp/topics/mc-gcp_apis.html
-- name: Fetch listing of Enabled GCP Service APIs
-  command: >
-    gcloud services list --enabled --project {{ plat__gcp_project }}
-  register: __gcp_services_info
+- name: Ensure Google Services Enabled
+  when: plat__gcp_enable_services | bool
+  block:
+    - name: Fetch list of enabled GCP Services
+      command: >
+        gcloud services list --enabled --project {{ plat__gcp_project }}
+      register: __gcp_services_info
 
-- name: Determine list of missing APIs
-  set_fact:
-    __plat_gcp_services_to_enable: "{{ __plat_gcp_services_to_enable | default([]) + ([__gcp_service_item] if __gcp_service_item not in __gcp_services_info.stdout else []) | unique }}"
-  loop: "{{ plat__gcp_required_services }}"
-  loop_control:
-    loop_var: __gcp_service_item
+    - name: Determine list of missing Services
+      set_fact:
+        __plat_gcp_services_to_enable: "{{ __plat_gcp_services_to_enable | default([]) + ([__gcp_service_item] if __gcp_service_item not in __gcp_services_info.stdout else []) | unique }}"
+      loop: "{{ plat__gcp_required_services }}"
+      loop_control:
+        loop_var: __gcp_service_item
 
-- name: Enable missing GCP Service APIs
-  when: __plat_gcp_services_to_enable | length > 0
-  command: >
-    gcloud services enable --quiet {{ __gcp_enable_item }}
-  loop: "{{ __plat_gcp_services_to_enable }}"
-  loop_control:
-    loop_var: __gcp_enable_item
+    - name: Enable missing GCP Service APIs
+      when: __plat_gcp_services_to_enable | length > 0
+      command: >
+        gcloud services enable --quiet {{ __gcp_enable_item }}
+      loop: "{{ __plat_gcp_services_to_enable }}"
+      loop_control:
+        loop_var: __gcp_enable_item

--- a/roles/platform/tasks/setup_gcp_authz.yml
+++ b/roles/platform/tasks/setup_gcp_authz.yml
@@ -14,161 +14,166 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Create a temporary directory for Credentials
-  ansible.builtin.tempfile:
-    prefix: "gcp-creds-"
-    state: directory
-  register: __gcp_creds_tmpdir
+- name: Create or update GCP Identities and Roles
+  when: plat__gcp_manage_identities | bool
+  block:
+    - name: Create a temporary directory for Credentials
+      ansible.builtin.tempfile:
+        prefix: "gcp-creds-"
+        state: directory
+      register: __gcp_creds_tmpdir
 
-- name: Create GCP xaccount service account
-  register: __gcp_xaccount_sa_info
-  google.cloud.gcp_iam_service_account:
-    name: "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    display_name: "{{ plat__gcp_xaccount_identity_name }}"
-    project: "{{ plat__gcp_project }}"
-    state: present
+    - name: Create GCP xaccount service account
+      register: __gcp_xaccount_sa_info
+      google.cloud.gcp_iam_service_account:
+        name: "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+        display_name: "{{ plat__gcp_xaccount_identity_name }}"
+        project: "{{ plat__gcp_project }}"
+        state: present
 
-- name: Set GCP Cross Account Bindings
-  register: __gcp_xaccount_bind_info
-  loop_control:
-    loop_var: __gcp_sa_binding_item
-  loop: "{{ plat__gcp_xaccount_policy_bindings }}"
-  command: >
-    gcloud projects
-    add-iam-policy-binding {{ plat__gcp_project }}
-    --member="serviceAccount:{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    --role={{ __gcp_sa_binding_item |quote }}
-    --no-user-output-enabled
-    --condition=None
+    - name: Set GCP Cross Account Bindings
+      register: __gcp_xaccount_bind_info
+      loop_control:
+        loop_var: __gcp_sa_binding_item
+      loop: "{{ plat__gcp_xaccount_policy_bindings }}"
+      command: >
+        gcloud projects
+        add-iam-policy-binding {{ plat__gcp_project }}
+        --member="serviceAccount:{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+        --role={{ __gcp_sa_binding_item |quote }}
+        --no-user-output-enabled
+        --condition=None
 
-- name: Generate Key for Google Cross Account Service Account
-  google.cloud.gcp_iam_service_account_key:
-    service_account: "{{ __gcp_xaccount_sa_info }}"
-    private_key_type: TYPE_GOOGLE_CREDENTIALS_FILE
-    path: "{{ __gcp_creds_tmpdir.path }}/{{ plat__gcp_xaccount_identity_name }}-gcp-cred.json"
-    project: "{{ plat__gcp_project }}"
-    state: present
+    - name: Generate Key for Google Cross Account Service Account
+      google.cloud.gcp_iam_service_account_key:
+        service_account: "{{ __gcp_xaccount_sa_info }}"
+        private_key_type: TYPE_GOOGLE_CREDENTIALS_FILE
+        path: "{{ __gcp_creds_tmpdir.path }}/{{ plat__gcp_xaccount_identity_name }}-gcp-cred.json"
+        project: "{{ plat__gcp_project }}"
+        state: present
 
-- name: Create Cross Account Google CDP Credential
-  cloudera.cloud.env_cred:
-    state: present
-    cloud: "{{ plat__infra_type }}"
-    name: "{{ plat__xacccount_credential_name }}"
-    secret: "{{ __gcp_creds_tmpdir.path }}/{{ plat__gcp_xaccount_identity_name }}-gcp-cred.json"
+    - name: Create Cross Account Google CDP Credential
+      cloudera.cloud.env_cred:
+        state: present
+        cloud: "{{ plat__infra_type }}"
+        name: "{{ plat__xacccount_credential_name }}"
+        secret: "{{ __gcp_creds_tmpdir.path }}/{{ plat__gcp_xaccount_identity_name }}-gcp-cred.json"
 
-- name: Create Custom GCP Log Role
-  register: __gcp_role_creation_info
-  google.cloud.gcp_iam_role:
-    name: "{{ plat__gcp_log_role_name }}"
-    title: "{{ plat__gcp_log_role_name }}"
-    description: "{{ plat__gcp_log_role_name }}"
-    included_permissions: "{{ plat__gcp_log_role_perms }}"
-    project: "{{ plat__gcp_project }}"
-    state: present
-  failed_when:
-    - __gcp_role_creation_info.msg is defined
-    - "'GCP returned error' in __gcp_role_creation_info.msg"
-    - "'marked for deletion' not in __gcp_role_creation_info.msg"
+    - name: Create Custom GCP Log Role
+      register: __gcp_role_creation_info
+      google.cloud.gcp_iam_role:
+        name: "{{ plat__gcp_log_role_name }}"
+        title: "{{ plat__gcp_log_role_name }}"
+        description: "{{ plat__gcp_log_role_name }}"
+        included_permissions: "{{ plat__gcp_log_role_perms }}"
+        project: "{{ plat__gcp_project }}"
+        state: present
+      failed_when:
+        - __gcp_role_creation_info.msg is defined
+        - "'GCP returned error' in __gcp_role_creation_info.msg"
+        - "'marked for deletion' not in __gcp_role_creation_info.msg"
 
-- name: Undelete Custom Log role if recently marked for deletion
-  when:
-    - __gcp_role_creation_info.deleted is defined
-    - __gcp_role_creation_info.deleted | bool
-  ansible.builtin.command: >
-    gcloud iam roles
-    undelete {{ plat__gcp_log_role_name }}
-    --project={{ plat__gcp_project }}
-  register: __gcp_role_undelete
+    - name: Undelete Custom Log role if recently marked for deletion
+      when:
+        - __gcp_role_creation_info.deleted is defined
+        - __gcp_role_creation_info.deleted | bool
+      ansible.builtin.command: >
+        gcloud iam roles
+        undelete {{ plat__gcp_log_role_name }}
+        --project={{ plat__gcp_project }}
+      register: __gcp_role_undelete
 
-- name: Fetch resulting Custom GCP Log Role status
-  ansible.builtin.command: >
-    gcloud iam roles
-    describe {{ plat__gcp_log_role_name }}
-    --project={{ plat__gcp_project }}
-  register: __gcp_custom_log_role_info
-  failed_when:
-    - __gcp_custom_log_role_info.rc == 1
-    - "'NOT_FOUND:' not in __gcp_custom_log_role_info.stderr"
+    - name: Fetch resulting Custom GCP Log Role status
+      ansible.builtin.command: >
+        gcloud iam roles
+        describe {{ plat__gcp_log_role_name }}
+        --project={{ plat__gcp_project }}
+      register: __gcp_custom_log_role_info
+      failed_when:
+        - __gcp_custom_log_role_info.rc == 1
+        - "'NOT_FOUND:' not in __gcp_custom_log_role_info.stderr"
 
-- name: Fail when custom GCP Log Role is not available
-  ansible.builtin.assert:
-    that:
-      - "'includedPermissions:' in __gcp_custom_log_role_info.stdout"
-      - "'NOT_FOUND' not in __gcp_custom_log_role_info.stderr"
-    quiet: yes
-    fail_msg: |
-      Custom Log Role {{ plat__gcp_log_role_name }} could not be created or undeleted.
-      It is likely that the unique role_id was marked for deletion recently and you are in the GCloud no-reuse window.
-      This no-reuse of a role_id window is typically somewhere from 7-14 days after initial deletion, and lasts 30 days.
-      Please use a different name for your custom Role.
+    - name: Fail when custom GCP Log Role is not available
+      ansible.builtin.assert:
+        that:
+          - "'includedPermissions:' in __gcp_custom_log_role_info.stdout"
+          - "'NOT_FOUND' not in __gcp_custom_log_role_info.stderr"
+        quiet: yes
+        fail_msg: |
+          Custom Log Role {{ plat__gcp_log_role_name }} could not be created or undeleted.
+          It is likely that the unique role_id was marked for deletion recently and you are in the GCloud no-reuse window.
+          This no-reuse of a role_id window is typically somewhere from 7-14 days after initial deletion, and lasts 30 days.
+          Please use a different name for your custom Role.
 
-- name: Create Operational GCP Service Accounts
-  register: __gcp_identity_info
-  loop_control:
-    loop_var: __gcp_identity_item
-    label: __gcp_identity_item
-  loop:
-    - "{{ plat__gcp_log_identity_name }}"
-    - "{{ plat__gcp_datalakeadmin_identity_name }}"
-    - "{{ plat__gcp_ranger_audit_identity_name }}"
-    - "{{ plat__gcp_idbroker_identity_name }}"
-  google.cloud.gcp_iam_service_account:
-    name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    display_name: "{{ __gcp_identity_item }}"
-    project: "{{ plat__gcp_project }}"
-    state: present
+    - name: Create Operational GCP Service Accounts
+      register: __gcp_identity_info
+      loop_control:
+        loop_var: __gcp_identity_item
+        label: __gcp_identity_item
+      loop:
+        - "{{ plat__gcp_log_identity_name }}"
+        - "{{ plat__gcp_datalakeadmin_identity_name }}"
+        - "{{ plat__gcp_ranger_audit_identity_name }}"
+        - "{{ plat__gcp_idbroker_identity_name }}"
+      google.cloud.gcp_iam_service_account:
+        name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+        display_name: "{{ __gcp_identity_item }}"
+        project: "{{ plat__gcp_project }}"
+        state: present
 
-- name: Set Operational Service Account Policy Bindings
-  loop_control:
-    loop_var: __gcp_binding_item
-    label: __gcp_binding_item.member
-  loop:
-    # Logs
-    - member: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "projects/{{ plat__gcp_project }}/roles/{{ plat__gcp_log_role_name }}"
-      condition: "expression=resource.name == '{{ plat__gcp_log_role_name }}',title='{{ plat__gcp_log_role_name }}'"
-    # Data Access
-    - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_admin }}"
-      condition: "expression=resource.name == '{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_datalakeadmin_identity_name }}'"
-    - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_admin }}"
-      condition: "expression=resource.name == '//storage.googleapis.com/projects/_/buckets/{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_datalakeadmin_identity_name }}-fulladmin'"
-    - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_object_admin }}"
-      condition: "expression=resource.name == '{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_ranger_audit_identity_name }}'"
-    # Ranger Audit
-    - member: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_object_admin }}"
-      condition: "expression=resource.name == '//storage.googleapis.com/projects/_/buckets/{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_ranger_audit_identity_name }}-fulladmin'"
-    # ID Broker  / Assumer Role
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_workload_identity_user }}"
-      condition: "expression=resource.name.startsWith('{{ plat__namespace }}'),title='{{ plat__gcp_idbroker_identity_name }}'"
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_service_account_user }}"
-      condition: "None"
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_service_account_token_creator }}"
-      condition: "None"
-  command: >
-    gcloud projects
-    add-iam-policy-binding {{ plat__gcp_project }}
-    --member={{ __gcp_binding_item.member |quote }}
-    --role={{ __gcp_binding_item.role |quote }}
-    --condition={{ __gcp_binding_item.condition |quote }}
+    - name: Set Operational Service Account Policy Bindings
+      loop_control:
+        loop_var: __gcp_binding_item
+        label: __gcp_binding_item.member
+      loop:
+        # Logs
+        - member: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "projects/{{ plat__gcp_project }}/roles/{{ plat__gcp_log_role_name }}"
+          condition: "expression=resource.name == '{{ plat__gcp_log_role_name }}',title='{{ plat__gcp_log_role_name }}'"
+        # Data Access
+        - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_admin }}"
+          condition: "expression=resource.name == '{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_datalakeadmin_identity_name }}'"
+        - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_admin }}"
+          condition: "expression=resource.name == '//storage.googleapis.com/projects/_/buckets/{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_datalakeadmin_identity_name }}-fulladmin'"
+        - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_object_admin }}"
+          condition: "expression=resource.name == '{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_ranger_audit_identity_name }}'"
+        # Ranger Audit
+        - member: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_object_admin }}"
+          condition: "expression=resource.name == '//storage.googleapis.com/projects/_/buckets/{{ plat__gcp_storage_location_data }}',title='{{ plat__gcp_ranger_audit_identity_name }}-fulladmin'"
+        # ID Broker  / Assumer Role
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_workload_identity_user }}"
+          condition: "expression=resource.name.startsWith('{{ plat__namespace }}'),title='{{ plat__gcp_idbroker_identity_name }}'"
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_service_account_user }}"
+          condition: "None"
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_service_account_token_creator }}"
+          condition: "None"
+      command: >
+        gcloud projects
+        add-iam-policy-binding {{ plat__gcp_project }}
+        --member={{ __gcp_binding_item.member |quote }}
+        --role={{ __gcp_binding_item.role |quote }}
+        --condition={{ __gcp_binding_item.condition |quote }}
 
-- name: Add Service Accounts to Storage Policies for Buckets
-  loop_control:
-    loop_var: __gcp_pol_item
-  loop:
-    - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
-      bucket: "{{ plat__gcp_storage_location_logs }}"
-    - account: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
-      bucket: "{{ plat__gcp_storage_location_data }}"
-    - account: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
-      bucket: "{{ plat__gcp_storage_location_data }}"
-  command: >
-    gsutil iam
-    ch {{ __gcp_pol_item.account |quote }}
-    gs://{{ __gcp_pol_item.bucket |quote }}
+    - name: Add Service Accounts to Storage Policies for Buckets
+      loop_control:
+        loop_var: __gcp_pol_item
+      loop:
+        - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
+          bucket: "{{ plat__gcp_storage_location_logs }}"
+        - account: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
+          bucket: "{{ plat__gcp_storage_location_data }}"
+        - account: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
+          bucket: "{{ plat__gcp_storage_location_data }}"
+      command: >
+        gsutil iam
+        ch {{ __gcp_pol_item.account |quote }}
+        gs://{{ __gcp_pol_item.bucket |quote }}
+
+- pause:

--- a/roles/platform/tasks/setup_gcp_authz.yml
+++ b/roles/platform/tasks/setup_gcp_authz.yml
@@ -175,5 +175,3 @@
         gsutil iam
         ch {{ __gcp_pol_item.account |quote }}
         gs://{{ __gcp_pol_item.bucket |quote }}
-
-- pause:

--- a/roles/platform/tasks/teardown_gcp_authz.yml
+++ b/roles/platform/tasks/teardown_gcp_authz.yml
@@ -14,108 +14,111 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Delete CDP Cross Account Access during Teardown
-  when: plat__teardown_deletes_credential
-  cloudera.cloud.env_cred:
-    state: absent
-    name: "{{ plat__xacccount_credential_name }}"
+- name: Handle GCP Identities and Roles and Policies during Teardown
+  when: plat__gcp_manage_identities | bool
+  block:
+    - name: Delete CDP Cross Account Access during Teardown
+      when: plat__teardown_deletes_credential
+      cloudera.cloud.env_cred:
+        state: absent
+        name: "{{ plat__xacccount_credential_name }}"
 
-- name: Remove GCP Cross Account Service Account Keys during Teardown
-  when:
-    - plat__gcp_xaccount_keys is defined
-    - __gcp_xaccount_key_item.keyType == 'USER_MANAGED'
-  loop: "{{ plat__gcp_xaccount_keys }}"
-  loop_control:
-    loop_var: __gcp_xaccount_key_item
-  command: >
-    gcloud iam service-accounts keys delete
-    {{ __gcp_xaccount_key_item.name.split('/')[-1] }}
-    --iam-account "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+    - name: Remove GCP Cross Account Service Account Keys during Teardown
+      when:
+        - plat__gcp_xaccount_keys is defined
+        - __gcp_xaccount_key_item.keyType == 'USER_MANAGED'
+      loop: "{{ plat__gcp_xaccount_keys }}"
+      loop_control:
+        loop_var: __gcp_xaccount_key_item
+      command: >
+        gcloud iam service-accounts keys delete
+        {{ __gcp_xaccount_key_item.name.split('/')[-1] }}
+        --iam-account "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
 
-- name: Remove GCP Cross Account Service Account
-  when: plat__teardown_deletes_xaccount
-  google.cloud.gcp_iam_service_account:
-    name: "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    project: "{{ plat__gcp_project }}"
-    state: absent
+    - name: Remove GCP Cross Account Service Account
+      when: plat__teardown_deletes_xaccount
+      google.cloud.gcp_iam_service_account:
+        name: "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+        project: "{{ plat__gcp_project }}"
+        state: absent
 
-- name: Tear down GCP Custom Log Role
-  when: plat__teardown_deletes_gcp_custom_roles
-  register: __gcp_role_teardown
-  failed_when:
-    - __gcp_role_teardown.msg is defined
-    - "'GCP returned error' in __gcp_role_teardown.msg"
-    - "'it is already deleted' not in __gcp_role_teardown.msg"
-  google.cloud.gcp_iam_role:
-    name: "{{ plat__gcp_log_role_name }}"
-    project: "{{ plat__gcp_project }}"
-    state: absent
+    - name: Tear down GCP Custom Log Role
+      when: plat__teardown_deletes_gcp_custom_roles
+      register: __gcp_role_teardown
+      failed_when:
+        - __gcp_role_teardown.msg is defined
+        - "'GCP returned error' in __gcp_role_teardown.msg"
+        - "'it is already deleted' not in __gcp_role_teardown.msg"
+      google.cloud.gcp_iam_role:
+        name: "{{ plat__gcp_log_role_name }}"
+        project: "{{ plat__gcp_project }}"
+        state: absent
 
-- name: Tear down Operational GCP Service Accounts Policies
-  when: plat__teardown_deletes_policies
-  register: __gcp_service_account_teardown
-  loop_control:
-    loop_var: __gcp_binding_item
-    label: __gcp_binding_item.member
-  failed_when:
-    - __gcp_service_account_teardown.rc == 1
-    - "'Policy bindings with the specified principal and role not found!' not in __gcp_service_account_teardown.stderr"
-  loop:
-    # Logs
-    - member: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "projects/{{ plat__gcp_project }}/roles/{{ plat__gcp_log_role_name }}"
-    # Data Access
-    - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_admin }}"
-    - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_object_admin }}"
-      # Ranger Audit
-    - member: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.storage_object_admin }}"
-    # ID Broker  / Assumer Role
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_workload_identity_user }}"
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_service_account_user }}"
-    - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      role: "{{ plat__gcp_roles.iam_service_account_token_creator }}"
-  command: >
-    gcloud projects
-    remove-iam-policy-binding {{ plat__gcp_project }}
-    --member={{ __gcp_binding_item.member |quote }}
-    --role={{ __gcp_binding_item.role |quote }}
-    --all
+    - name: Tear down Operational GCP Service Accounts Policies
+      when: plat__teardown_deletes_policies
+      register: __gcp_service_account_teardown
+      loop_control:
+        loop_var: __gcp_binding_item
+        label: __gcp_binding_item.member
+      failed_when:
+        - __gcp_service_account_teardown.rc == 1
+        - "'Policy bindings with the specified principal and role not found!' not in __gcp_service_account_teardown.stderr"
+      loop:
+        # Logs
+        - member: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "projects/{{ plat__gcp_project }}/roles/{{ plat__gcp_log_role_name }}"
+        # Data Access
+        - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_admin }}"
+        - member: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_object_admin }}"
+          # Ranger Audit
+        - member: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.storage_object_admin }}"
+        # ID Broker  / Assumer Role
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_workload_identity_user }}"
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_service_account_user }}"
+        - member: "serviceAccount:{{ plat__gcp_idbroker_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          role: "{{ plat__gcp_roles.iam_service_account_token_creator }}"
+      command: >
+        gcloud projects
+        remove-iam-policy-binding {{ plat__gcp_project }}
+        --member={{ __gcp_binding_item.member |quote }}
+        --role={{ __gcp_binding_item.role |quote }}
+        --all
 
-- name: Tear down GCP Storage Policies
-  when: plat__teardown_deletes_policies
-  register: __gcp_storage_policy_teardown
-  loop_control:
-    loop_var: __gcp_pol_item
-  failed_when:
-    - __gcp_storage_policy_teardown.rc == 1
-    - "'BucketNotFoundException:' not in __gcp_storage_policy_teardown.stderr"
-  loop:
-    - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      bucket: "{{ plat__gcp_storage_location_logs }}"
-    - account: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      bucket: "{{ plat__gcp_storage_location_data }}"
-    - account: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-      bucket: "{{ plat__gcp_storage_location_data }}"
-  command: >
-    gsutil iam
-    ch -d {{ __gcp_pol_item.account |quote }}
-    gs://{{ __gcp_pol_item.bucket |quote }}
+    - name: Tear down GCP Storage Policies
+      when: plat__teardown_deletes_policies
+      register: __gcp_storage_policy_teardown
+      loop_control:
+        loop_var: __gcp_pol_item
+      failed_when:
+        - __gcp_storage_policy_teardown.rc == 1
+        - "'BucketNotFoundException:' not in __gcp_storage_policy_teardown.stderr"
+      loop:
+        - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          bucket: "{{ plat__gcp_storage_location_logs }}"
+        - account: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          bucket: "{{ plat__gcp_storage_location_data }}"
+        - account: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+          bucket: "{{ plat__gcp_storage_location_data }}"
+      command: >
+        gsutil iam
+        ch -d {{ __gcp_pol_item.account |quote }}
+        gs://{{ __gcp_pol_item.bucket |quote }}
 
-- name: Tear down Operational GCP Service Accounts
-  when: plat__teardown_deletes_roles
-  loop_control:
-    loop_var: __gcp_identity_item
-  loop:
-    - "{{ plat__gcp_log_identity_name }}"
-    - "{{ plat__gcp_datalakeadmin_identity_name }}"
-    - "{{ plat__gcp_ranger_audit_identity_name }}"
-    - "{{ plat__gcp_idbroker_identity_name }}"
-  google.cloud.gcp_iam_service_account:
-    name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    project: "{{ plat__gcp_project }}"
-    state: absent
+    - name: Tear down Operational GCP Service Accounts
+      when: plat__teardown_deletes_roles
+      loop_control:
+        loop_var: __gcp_identity_item
+      loop:
+        - "{{ plat__gcp_log_identity_name }}"
+        - "{{ plat__gcp_datalakeadmin_identity_name }}"
+        - "{{ plat__gcp_ranger_audit_identity_name }}"
+        - "{{ plat__gcp_idbroker_identity_name }}"
+      google.cloud.gcp_iam_service_account:
+        name: "{{ __gcp_identity_item }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+        project: "{{ plat__gcp_project }}"
+        state: absent


### PR DESCRIPTION
Add options to control whether Ansible will manage GCP identities, roles, services, and policies for the user. These commands fail if the user does not have permission to change that setting, whether already enabled/created or not, and typically BYOI will already have these created by a Cloud Admin team.

Added env.gcp.manage_identities to control deploy and teardown of GCP credentials, identities and roles. Defaults to True to match existing behavior.
Added env.gcp.auto_enable_services to control enabling of required GCP services for CDP. Defaults to True to match existing behavior

Signed-off-by: Daniel Chaffelson <chaffelson@gmail.com>