### PR TITLE
Update CentOS 7 AMI search terms

### DIFF
--- a/roles/infrastructure/tasks/initialize_setup_aws.yml
+++ b/roles/infrastructure/tasks/initialize_setup_aws.yml
@@ -70,6 +70,7 @@
         region: "{{ infra__region }}"
         filters:
           name: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os].search }}"
+          product-code: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os]['product-code'] | default(omit) }}"
         owners: "{{ infra__dynamic_inventory_images_default[infra__type][infra__dynamic_inventory_os].owners }}"
       register: __infra_aws_ami_list
 

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -29,10 +29,10 @@ infra__cdp_control_plane_cidr_default:  ['52.36.110.208/32', '52.40.165.49/32', 
 infra__dynamic_inventory_images_default:
   aws:
     el7:
-      search: 'CentOS Linux 7 x86_64 HVM EBS*'
+      search: 'CentOS 7.9.*x86_64'
       user: 'centos'
       owners:
-        - 'aws-marketplace'
+        - '125523088429'
     el8:
       search: 'RHEL-8.4*HVM*x86_64*'
       user: 'ec2-user'

--- a/roles/infrastructure/vars/main.yml
+++ b/roles/infrastructure/vars/main.yml
@@ -29,10 +29,11 @@ infra__cdp_control_plane_cidr_default:  ['52.36.110.208/32', '52.40.165.49/32', 
 infra__dynamic_inventory_images_default:
   aws:
     el7:
-      search: 'CentOS 7.9.*x86_64'
+      search: 'CentOS-7*x86_64*'
       user: 'centos'
+      product-code: 'cvugziknvmxgqna9noibqnnsy'
       owners:
-        - '125523088429'
+        - '679593333241'
     el8:
       search: 'RHEL-8.4*HVM*x86_64*'
       user: 'ec2-user'


### PR DESCRIPTION
The details of the CentOS 7 Amazon AMI image have changed recently. 

This PR changes the search terms (owner and search string) to find the CentOS 7 AWS image.

Signed-off-by: Jim Enright <jenright@cloudera.com>