### PR TITLE
Add support to choosing the GCP subnet to deploy to.

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -136,6 +136,7 @@ common__azure_netapp_nfs_version:         "{{ infra.azure.netapp.nfs.version | d
 # GCP Infra
 common__gcp_project:                      "{{ infra.gcp.project | default('gcp-se') }}"
 common__gcp_region:                       "{{ infra.gcp.region | default('europe-west1') }}"
+common__gcp_subnet_id:                    "{{ infra.gcp.vpc.subnet_id | default(None) }}"
 
 # Plat
 common__xaccount_credential_suffix:       "{{ env.cdp.credential.suffix | default(common__xaccount_suffix) }}"

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -145,6 +145,7 @@ plat__aws_policy_urls:                        "{{ plat__aws_policy_urls_default 
 
 # GCP
 plat__gcp_project:                            "{{ common__gcp_project }}"
+plat__gcp_subnet_id:                          "{{ common__gcp_subnet_id }}"
 
 plat__gcp_role_suffix:                        "{{ env.gcp.role.suffix | default(common__role_suffix) }}"
 plat__gcp_storage_suffix:                     "{{ env.gcp.storage.suffix | default(common__storage_suffix) }}"

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -27,7 +27,7 @@
     log_identity: "{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
     vpc_id: "{{ plat__vpc_name }}"
     subnet_ids:
-      - "{{ plat__gcp_subnets_discovered[0].name }}"  # TODO - Check in validation_gcp.yml -- CDP on GCP only supports a single subnet deployment
+      - "{{ plat__gcp_subnet_id if plat__gcp_subnet_id else plat__gcp_subnets_discovered[0].name }}"  # TODO - Check in validation_gcp.yml -- CDP on GCP only supports a single subnet deployment
     project: "{{ plat__gcp_project }}"
     tunnel: "{{ plat__tunnel }}"
     workload_analytics: "{{ plat__workload_analytics }}"


### PR DESCRIPTION
If `infra.gcp.vpc.subnet_id` is set, it will use that specified subnet for deploying the environment. Otherwise, it will use the first subnet found as has been the case so far.

Note that this property is under `infra.gpc.vpc` while other properties like the VPC name are under `infra.vpc`.  
I think that's confusing but it put it under `infra.gcp.vpc` for consistency with similar properties for other cloud providers (e.g., `infra.aws.vpc.existing.public_subnet_ids`) and anyway, VPC properties seem to already be split between both places (e.g., `infra.aws.vpc.nat_gateway.name`, `infra.aws.vpc.private_endpoints`, etc. vs. `infra.vpc.private_subnets`, `infra.vpc.enable_ssh`, etc.).

I tested it by deploying GPC environments where I either specifically provided a subnet name that was different than the first one or didn't provide the subnet name to let it choose the first one and in both cases the result was the expected one.