### PR TITLE
Add support to GPC shared VPCs

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -86,6 +86,7 @@ common__terraform_remote_state_bucket:     "{{ globals.terraform.remote_state_bu
 common__terraform_remote_state_lock_table: "{{ globals.terraform.remote_state_lock_table | default('') }}"      
 
 common__vpc_name:                         "{{ infra.vpc.name | default([common__namespace, common__vpc_name_suffix] | join('-')) }}"
+common__vpc_project:                      "{{ infra.vpc.project_id | default(omit) }}"
 common__vpc_public_subnet_cidrs:          "{{ infra.vpc.public_subnets | default(['10.10.0.0/19', '10.10.32.0/19', '10.10.64.0/19']) }}"
 common__vpc_private_subnet_cidrs:         "{{ infra.vpc.private_subnets | default(['10.10.96.0/19', '10.10.128.0/19', '10.10.160.0/19']) }}"
 common__vpc_private_subnets_suffix:       "{{ infra.vpc.public_subnets_suffix | default([common__vpc_subnet_suffix, common__private_suffix] | join('-')) }}"

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -48,6 +48,7 @@ plat__cdp_iam_resource_suffix:                "{{ plat__cdp_iam_identities.resou
 plat__tags:                                   "{{ common__tags }}"
 plat__env_name:                               "{{ common__env_name }}"
 plat__vpc_name:                               "{{ common__vpc_name }}"
+plat__vpc_project:                            "{{ common__vpc_project }}"
 plat__storage_name:                           "{{ common__storage_name }}"
 
 plat__logs_path:                              "{{ common__logs_path }}"

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -26,6 +26,7 @@
     log_location: "gs://{{ plat__gcp_storage_location_logs }}"
     log_identity: "{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
     vpc_id: "{{ plat__vpc_name }}"
+    vpc_project_id: "{{ plat__vpc_project }}"
     subnet_ids:
       - "{{ plat__gcp_subnet_id if plat__gcp_subnet_id else plat__gcp_subnets_discovered[0].name }}"  # TODO - Check in validation_gcp.yml -- CDP on GCP only supports a single subnet deployment
     project: "{{ plat__gcp_project }}"


### PR DESCRIPTION
Adds support to providing a different GCP project id for the VPC as required for using shared VPCs.

This has been tested for the last month by the customer this was developed for, who has been deploying all their clusters with a shared VPC with this change.

Required https://github.com/cloudera-labs/cloudera.cloud/pull/83