### PR TITLE
Move listing cross account keys to teardown playbook.

### DIFF
--- a/roles/platform/tasks/initialize_gcp.yml
+++ b/roles/platform/tasks/initialize_gcp.yml
@@ -52,22 +52,3 @@
   loop: "{{ __gcp_subnets_discovered.resources }}"
   loop_control:
     loop_var: __gcp_subnet_item
-
-- name: Discover GCP Cross Account Service Account Keys
-  register: __gcp_xaccount_sa_discovered
-  failed_when:
-    - __gcp_xaccount_sa_discovered.rc == 1
-    - "'NOT_FOUND:' not in __gcp_xaccount_sa_discovered.stderr"
-    - "'Permission iam.serviceAccountKeys.list' not in __gcp_xaccount_sa_discovered.stderr"
-  command: >
-    gcloud iam service-accounts keys list
-    --iam-account "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    --format="json"
-
-- name: Set discovered Cross Account Service Account keys if exists
-  when:
-    - __gcp_xaccount_sa_discovered is defined
-    - __gcp_xaccount_sa_discovered.stdout is defined
-    - __gcp_xaccount_sa_discovered.stdout | length > 0
-  ansible.builtin.set_fact:
-    plat__gcp_xaccount_keys: "{{ __gcp_xaccount_sa_discovered.stdout | from_json }}"

--- a/roles/platform/tasks/initialize_teardown_gcp.yml
+++ b/roles/platform/tasks/initialize_teardown_gcp.yml
@@ -13,3 +13,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+- name: Discover GCP Cross Account Service Account Keys
+  register: __gcp_xaccount_sa_discovered
+  failed_when:
+    - __gcp_xaccount_sa_discovered.rc == 1
+    - "'NOT_FOUND:' not in __gcp_xaccount_sa_discovered.stderr"
+    - "'Permission iam.serviceAccountKeys.list' not in __gcp_xaccount_sa_discovered.stderr"
+  command: >
+    gcloud iam service-accounts keys list
+    --iam-account "{{ plat__gcp_xaccount_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+    --format="json"
+
+- name: Set discovered Cross Account Service Account keys if exists
+  when:
+    - __gcp_xaccount_sa_discovered is defined
+    - __gcp_xaccount_sa_discovered.stdout is defined
+    - __gcp_xaccount_sa_discovered.stdout | length > 0
+  ansible.builtin.set_fact:
+    plat__gcp_xaccount_keys: "{{ __gcp_xaccount_sa_discovered.stdout | from_json }}"


### PR DESCRIPTION
That task requires privileges that may be restricted and it's used to set the `plat__gcp_xaccount_keys` variable which is only used during the teardown phase, so this PR moves this task to where it's used removing any additional permission that may be needed to run this task during deployments when it's not really needed.

This has been tested by doing full deployment + teardown of a cluster (infra + plat + run).