### PR TITLE
Don't run GPC VPC discovery tasks when the subnet was already specified.

### DIFF
--- a/roles/platform/tasks/initialize_gcp.yml
+++ b/roles/platform/tasks/initialize_gcp.yml
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 - name: Discover GCP VPC
+  when: not plat__gcp_subnet_id
   google.cloud.gcp_compute_network_info:
     project: "{{ plat__gcp_project }}"
     filters:


### PR DESCRIPTION
The VPC network and subnet discovery tasks that run in `roles/platform/tasks/initialize_gcp.yml` may require additional privileges and are only required to find a subnet to deploy to when not specified. When the subnet is already specified in `infra.gcp.vpc.subnet_id` those tasks are not required.

This PR skips those tasks when the subnet is already specified. I needed it for a project where listing GCP subnets was not allowed, so it was already tested.
I also tested that it still works as before when you don't provide a subnet.