### PR TITLE
Allow skipping GCP availability zones validation.

### DIFF
--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -174,6 +174,7 @@ plat__gcp_log_role_perms:                     "{{ env.gcp.bindings.logs | defaul
 
 plat__gcp_manage_identities:                  "{{ env.gcp.manage_identities | default(true) }}"
 plat__gcp_enable_services:                    "{{ env.gcp.auto_enable_services | default(true) }}"
+plat__gcp_check_availability_zones:           "{{ infra.gcp.check_availability_zones | default(true) }}"
 
 # Azure
 plat__azure_app_suffix:                       "{{ env.azure.app.suffix | default(common__app_suffix) }}"

--- a/roles/platform/tasks/initialize_setup_gcp.yml
+++ b/roles/platform/tasks/initialize_setup_gcp.yml
@@ -15,6 +15,9 @@
 # limitations under the License.
 
 - name: Discover available zones for GCP region
+  when:
+    - plat__gcp_check_availability_zones
+    - plat__gcp_availability_zones | length > 0
   block:
     - name: Fetch list of availability zones filtered by region
       ansible.builtin.command: >
@@ -26,7 +29,6 @@
         plat__gcp_availability_zones_discovered: "{{ __gcp_availability_zones_info.stdout | from_json | map(attribute='name') | list }}"
 
     - name: Confirm availability zone access for CDP Environment
-      when: plat__gcp_availability_zones | length > 0
       ansible.builtin.assert:
         that:
           - plat__gcp_availability_zones is subset(plat__gcp_availability_zones_discovered)


### PR DESCRIPTION
This PR adds a new property `infra.gcp.check_availability_zones` which would allow skipping the tasks that list GCP availability zones and check if the one we are trying to deploy to exists there.
This is being introduced because listing availability zones may be blocked by organization policies making this task fail.

Also, the original code was listing availability zones unconditionally but was checking if the chosen availability zone is present in that list only if an availability zone was provided (`plat__gcp_availability_zones | length > 0`). This PR also moves that condition to apply it to the the whole block and not only the last task so listing availability zones is also skipped when no availability zones were chosen.

This was tested by trying to deploy a cluster to an invalid availability zone with `infra.gcp.check_availability_zones` unset to confirm that it still fails while validating availability zones as before and also trying to deploy a cluster to an invalid availability zone with `infra.gcp.check_availability_zones` set to `true` which fails when it tries to deploy the environment to GCP as expected.