### PR TITLE
GCP: Add support for specifying the backups storage bucket.

### DIFF
--- a/docs/configuration.yml
+++ b/docs/configuration.yml
@@ -268,6 +268,7 @@ env:
       suffix:
     storage:
       path:
+        backups:
         data:
         logs:
       suffix:
@@ -419,6 +420,7 @@ infra:
     region:
     storage:
       path:
+        backups:
         data:
         logs:
   security_group:
@@ -434,6 +436,7 @@ infra:
   storage:
     name:
     path:
+      backups:
       data:
       de:
       logs:

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -104,6 +104,7 @@ common__ml_path:                          "{{ infra.storage.path.ml | default('d
 common__de_path:                          "{{ infra.storage.path.de | default('dataeng') }}"
 common__logs_path:                        "{{ infra.storage.path.logs | default(common__logs_suffix) }}"
 common__data_path:                        "{{ infra.storage.path.data | default(common__data_suffix) }}"
+common__backups_path:                     "{{ infra.storage.path.backups | default(common__logs_path) }}"
 common__ranger_audit_path:                "{{ infra.storage.path.ranger_audit | default('ranger/audit') }}"
 
 # AWS Infra

--- a/roles/infrastructure/defaults/main.yml
+++ b/roles/infrastructure/defaults/main.yml
@@ -68,6 +68,7 @@ infra__storage_name:                "{{ common__storage_name }}"
 
 infra__logs_path:                   "{{ common__logs_path }}"
 infra__data_path:                   "{{ common__data_path }}"
+infra__backups_path:                "{{ common__backups_path }}"
 infra__ranger_audit_path:           "{{ common__ranger_audit_path }}"
 
 infra__public_key_path:             "{{ globals.ssh.key_path | default('~/.ssh') }}"
@@ -133,8 +134,9 @@ infra__aws_private_endpoints:       "{{ infra.aws.vpc.private_endpoints | defaul
 # GCP
 infra__gcp_project:                 "{{ common__gcp_project }}"
 
-infra__gcp_storage_location_data:   "{{ infra.gcp.storage.path.data | default([infra__storage_name, infra__data_path] | join('-')) }}"
-infra__gcp_storage_location_logs:   "{{ infra.gcp.storage.path.logs | default([infra__storage_name, infra__logs_path] | join('-')) }}"
+infra__gcp_storage_location_data:    "{{ infra.gcp.storage.path.data | default([infra__storage_name, infra__data_path] | join('-')) }}"
+infra__gcp_storage_location_logs:    "{{ infra.gcp.storage.path.logs | default([infra__storage_name, infra__logs_path] | join('-')) }}"
+infra__gcp_storage_location_backups: "{{ infra.gcp.storage.path.backups | default(infra__gcp_storage_location_logs) }}"
 
 infra__gcp_cloud_router_name_suffix:  "{{ infra.gcp.network.router.name_suffix | default('router') }}"
 infra__gcp_cloud_router_name:         "{{ infra.gcp.network.router.name | default([infra__namespace, infra__gcp_cloud_router_name_suffix] | join('-')) }}"

--- a/roles/infrastructure/tasks/initialize_gcp.yml
+++ b/roles/infrastructure/tasks/initialize_gcp.yml
@@ -38,7 +38,7 @@
     fail_msg: "Gcloud Collection failed to retrieve resources, you may need to run 'gcloud auth login' or 'gcloud init': {{ __gcp_vpc_info }}"
     quiet: yes
 
-- name: Set fact for Log and Data locations
+- name: Set fact for Log, Backups and Data locations
   ansible.builtin.set_fact:
     infra__gcp_storage_locations: "{{ infra__gcp_storage_locations | default([]) | union([__gcp_storage_location_item]) }}"
   loop_control:
@@ -46,3 +46,4 @@
   loop:
     - "{{ infra__gcp_storage_location_data }}"
     - "{{ infra__gcp_storage_location_logs }}"
+    - "{{ infra__gcp_storage_location_backups }}"

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -52,7 +52,7 @@ plat__storage_name:                           "{{ common__storage_name }}"
 
 plat__logs_path:                              "{{ common__logs_path }}"
 plat__data_path:                              "{{ common__data_path }}"
-plat__data_path:                              "{{ common__backups_path }}"
+plat__backup_path:                            "{{ common__backups_path }}"
 
 plat__public_key_id:                          "{{ common__public_key_id }}"
 plat__public_key_text:                        "{{ common__public_key_text }}"

--- a/roles/platform/defaults/main.yml
+++ b/roles/platform/defaults/main.yml
@@ -52,6 +52,7 @@ plat__storage_name:                           "{{ common__storage_name }}"
 
 plat__logs_path:                              "{{ common__logs_path }}"
 plat__data_path:                              "{{ common__data_path }}"
+plat__data_path:                              "{{ common__backups_path }}"
 
 plat__public_key_id:                          "{{ common__public_key_id }}"
 plat__public_key_text:                        "{{ common__public_key_text }}"
@@ -168,6 +169,7 @@ plat__gcp_idbroker_identity_name:             "{{ env.gcp.role.name.idbroker | d
 
 plat__gcp_storage_location_data:              "{{ env.gcp.storage.path.data | default([plat__storage_name, plat__data_path] | join('-')) }}"
 plat__gcp_storage_location_logs:              "{{ env.gcp.storage.path.logs | default([plat__storage_name, plat__logs_path] | join('-')) }}"
+plat__gcp_storage_location_backups:           "{{ env.gcp.storage.path.backups | default(plat__gcp_storage_location_logs) }}"
 
 plat__gcp_xaccount_policy_bindings:           "{{ env.gcp.bindings.cross_account | default(plat__gcp_xaccount_policy_bindings_default) }}"
 plat__gcp_log_role_perms:                     "{{ env.gcp.bindings.logs | default(plat__gcp_log_policy_bindings_default) }}"

--- a/roles/platform/tasks/setup_gcp_authz.yml
+++ b/roles/platform/tasks/setup_gcp_authz.yml
@@ -167,6 +167,8 @@
       loop:
         - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
           bucket: "{{ plat__gcp_storage_location_logs }}"
+        - account: "serviceAccount:{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
+          bucket: "{{ plat__gcp_storage_location_backups }}"
         - account: "serviceAccount:{{ plat__gcp_datalakeadmin_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"
           bucket: "{{ plat__gcp_storage_location_data }}"
         - account: "serviceAccount:{{ plat__gcp_ranger_audit_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com:admin"

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -25,6 +25,7 @@
     public_ip: "{{ plat__use_public_ip }}"
     log_location: "gs://{{ plat__gcp_storage_location_logs }}"
     log_identity: "{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
+    backups_location: "gs://{{ plat__gcp_storage_location_backups }}"
     vpc_id: "{{ plat__vpc_name }}"
     subnet_ids:
       - "{{ plat__gcp_subnet_id if plat__gcp_subnet_id else plat__gcp_subnets_discovered[0].name }}"  # TODO - Check in validation_gcp.yml -- CDP on GCP only supports a single subnet deployment

--- a/roles/platform/tasks/setup_gcp_env.yml
+++ b/roles/platform/tasks/setup_gcp_env.yml
@@ -25,7 +25,7 @@
     public_ip: "{{ plat__use_public_ip }}"
     log_location: "gs://{{ plat__gcp_storage_location_logs }}"
     log_identity: "{{ plat__gcp_log_identity_name }}@{{ plat__gcp_project }}.iam.gserviceaccount.com"
-    backups_location: "gs://{{ plat__gcp_storage_location_backups }}"
+    backup_location: "gs://{{ plat__gcp_storage_location_backups }}"
     vpc_id: "{{ plat__vpc_name }}"
     subnet_ids:
       - "{{ plat__gcp_subnet_id if plat__gcp_subnet_id else plat__gcp_subnets_discovered[0].name }}"  # TODO - Check in validation_gcp.yml -- CDP on GCP only supports a single subnet deployment


### PR DESCRIPTION
Incorporating PR#134 and required fixes to work with cloudera.cloud.env.

Note - to test creation and use of the backup storage bucket we found that we needed to specify both the `infra.gcp.storage.path.backups` and `env.gcp.storage.path.backups` variables:

```yaml
env:
  gcp:
    storage:
      path:
        backups: "jegc-custom-backups"

infra:
  gcp:
    project: "{{ gcp_project_id }}"
    storage:
      path:
        backups: "jegc-custom-backups"

```