### PR TITLE
Add Minifi Java Agent Role

### DIFF
--- a/roles/minifi_agent_java/README.md
+++ b/roles/minifi_agent_java/README.md
@@ -1,0 +1,93 @@
+# MiNiFi Java Agent
+
+This role streamlines the deployment and configuration of Cloudera MiNiFi Java Agent on designated hosts.
+
+The role will:
+- Retrieve the MiNiFi Java tarball from a user-defined or default source
+- Install MiNiFi Java into a configurable directory
+- Apply configuration using a Jinja2 template for `minifi.properties`
+- Configure C2 protocol for communication with EFM server
+- Support TLS/SSL configuration for secure communication
+- Install and start the MiNiFi Java agent service
+- Support authentication for protected download sources
+
+## Requirements
+
+- Network access from the target host to the URL specified in `minifi_java_tarball_url`
+- Access to EFM server for C2 communication (specified in `efm_host_url`)
+- For TLS configuration: Valid certificates and private keys on target host
+
+## Variables
+
+| Name                            | Purpose                                                      | Default (see `defaults/main.yml`)           |
+|----------------------------------|--------------------------------------------------------------|---------------------------------------------|
+| `minifi_java_tarball_url`        | Download link for the MiNiFi Java tarball                   | (default provided in role)                  |
+| `minifi_java_directory`          | Installation directory for MiNiFi Java                      | `/opt/cloudera/cem/minifi-java`              |
+| `minifi_java_properties_path`    | Path to the MiNiFi Java properties file                     | `/opt/cloudera/cem/minifi-java/conf/minifi.properties` |
+| `minifi_java_agent_class_name`   | Agent class name for MiNiFi Java agent                      | `minifi-agent-java`                          |
+| `efm_host_url`                  | URL for the EFM server for C2 communication                 | `http://localhost:10090`                    |
+| `minifi_java_repo_username` | Username for protected repositories (optional)               |                                             |
+| `minifi_java_repo_password` | Password for protected repositories (optional)               |                                             |
+| `minifi_tls_enabled`            | Enable/disable TLS for MiNiFi Java agent                    | `false`                                     |
+| `minifi_tls_client_certificate` | Path to client certificate file for TLS authentication      | `/etc/pki/tls/certs/host.crt`              |
+| `minifi_tls_client_private_key` | Path to client private key file for TLS authentication      | `/etc/pki/tls/private/host.key`            |
+| `minifi_tls_client_ca_certificate` | Path to CA certificate file for TLS authentication       | `/etc/ipa/ca.crt`                          |
+| `minifi_java_service_path`       | Path to the systemd service file for MiNiFi Java.          | `/etc/systemd/system/minifi-java.service` |
+| `minifi_tls_keystore_path`       | Path to the keystore file for TLS configuration.           |                                             |
+| `minifi_tls_keystore_type`       | Type of the keystore (e.g., JKS, PKCS12).                  |                                             |
+| `minifi_tls_keystore_password`   | Password for the keystore file.                            |                                             |
+| `minifi_tls_key_password`        | Password for the private key in the keystore.              |                                             |
+| `minifi_tls_truststore_path`     | Path to the truststore file for TLS configuration.         |                                             |
+| `minifi_tls_truststore_type`     | Type of the truststore (e.g., JKS, PKCS12).                |                                             |
+| `minifi_tls_truststore_password` | Password for the truststore file.                          |                                             |
+| `minifi_tls_ssl_protocol`        | SSL protocol to use for TLS communication (e.g., TLSv1.2). |                                             |
+
+## Example usage
+
+```yaml
+# Basic MiNiFi Java installation
+- hosts: minifi_nodes
+  become: true
+  tasks:
+    - name: Install MiNiFi Java with basic configuration
+      ansible.builtin.import_role:
+        name: cloudera.exe.minifi_agent_java
+      vars:
+        minifi_java_repo_username: "repo_user"
+        minifi_java_repo_password: "repo_pass"
+        efm_host_url: "http://efm-server:10090"
+        minifi_java_agent_class_name: "java-agent"
+# MiNiFi Java installation with TLS configuration
+- hosts: minifi_nodes
+  become: true
+  tasks:
+    - name: Install MiNiFi Java with TLS enabled
+      ansible.builtin.import_role:
+        name: cloudera.exe.minifi_agent_java
+      vars:
+        efm_host_url: "https://efm-server:10090"
+        minifi_tls_enabled: true
+        minifi_tls_keystore_path: "/etc/pki/tls/keystore.jks"
+        minifi_tls_keystore_password: "keystore_password"
+        minifi_tls_truststore_path: "/etc/pki/tls/truststore.jks"
+        minifi_tls_truststore_password: "truststore_password"
+        minifi_tls_ssl_protocol: "TLSv1.2"
+```
+
+## License
+
+```
+Copyright 2025 Cloudera, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```

--- a/roles/minifi_agent_java/defaults/main.yml
+++ b/roles/minifi_agent_java/defaults/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+minifi_java_directory: "/opt/cloudera/cem/minifi-java"
+minifi_java_tarball_url: "https://archive.cloudera.com/p/cem-agents-java/1.23.04.1000/ubuntu20/apt/tars/nifi-minifi-java/minifi-1.23.04.1000-b3-bin.tar.gz"
+minifi_java_properties_path: "/opt/cloudera/cem/minifi-java/conf/bootstrap.conf"
+minifi_java_service_path: "/etc/systemd/system/minifi-java.service"
+efm_host_url: "http://localhost:10090"
+minifi_java_agent_class_name: "minifi-agent-java"
+
+# TLS Configuration
+minifi_tls_enabled: false
+# TLS settings (only used when minifi_tls_enabled is true)
+# minifi_tls_keystore_path: ""
+# minifi_tls_keystore_type: ""
+# minifi_tls_keystore_password: ""
+# minifi_tls_key_password: ""
+# minifi_tls_truststore_path: ""
+# minifi_tls_truststore_type: ""
+# minifi_tls_truststore_password: ""
+# minifi_tls_ssl_protocol: ""

--- a/roles/minifi_agent_java/handlers/main.yml
+++ b/roles/minifi_agent_java/handlers/main.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Start minifi-java service
+  ansible.builtin.systemd:
+    name: minifi-java
+    daemon_reload: true
+    enabled: true
+    state: started

--- a/roles/minifi_agent_java/meta/argument_specs.yml
+++ b/roles/minifi_agent_java/meta/argument_specs.yml
@@ -20,7 +20,7 @@ argument_specs:
       - Downloads, installs, and configures Cloudera MiNiFi C++ Agent on the target host.
       - Sets up the MiNiFi properties, and manages the systemd service.
     author: Cloudera Labs
-    version_added: "3.2.0"
+    version_added: "3.3.0"
     options:
       minifi_java_tarball_url:
         description: URL to the MiNiFi C++ tarball to download and install.

--- a/roles/minifi_agent_java/meta/argument_specs.yml
+++ b/roles/minifi_agent_java/meta/argument_specs.yml
@@ -1,0 +1,114 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+argument_specs:
+  main:
+    short_description: Install and configure Cloudera MiNiFi C++ Agent
+    description:
+      - Downloads, installs, and configures Cloudera MiNiFi C++ Agent on the target host.
+      - Sets up the MiNiFi properties, and manages the systemd service.
+    author: Cloudera Labs
+    version_added: "3.2.0"
+    options:
+      minifi_java_tarball_url:
+        description: URL to the MiNiFi C++ tarball to download and install.
+        type: str
+        required: false
+        default: "https://archive.cloudera.com/p/cem-agents/1.25.05-h2/ubuntu22/apt/tars/nifi-minifi-java/nifi-minifi-java-1.25.05-h2-b5-bin-linux.tar.gz"
+      minifi_java_directory:
+        description: Directory where MiNiFi C++ will be installed.
+        type: str
+        required: false
+        default: "/opt/cloudera/cem/minifi-java"
+      minifi_java_properties_path:
+        description: Path to the MiNiFi C++ properties file.
+        type: str
+        required: false
+        default: "/opt/cloudera/cem/minifi-java/conf/minifi.properties"
+      minifi_java_agent_class_name:
+        description: Agent class name for MiNiFi C++ agent.
+        type: str
+        required: false
+        default: "minifi-agent-java2"
+      efm_api_url:
+        description: URL for the Edge Flow Manager API.
+        type: str
+        required: false
+        default: "http://localhost:10090/efm/api"
+      minifi_java_repo_username:
+        description: Username for protected Minifi repositories.
+        type: str
+        required: false
+      minifi_java_repo_password:
+        description: Password for protected Minifi repositories.
+        type: str
+        required: false
+      efm_host_url:
+        description: URL for the Edge Flow Manager server for C2 communication.
+        type: str
+        default: "http://localhost:10090"
+      minifi_tls_enabled:
+        description: Enable or disable TLS for MiNiFi C++ agent.
+        type: bool
+        default: false
+      minifi_tls_client_certificate:
+        description: Path to the client certificate file for TLS authentication.
+        type: str
+        default: "/etc/pki/tls/certs/host.crt"
+      minifi_tls_client_private_key:
+        description: Path to the client private key file for TLS authentication.
+        type: str
+        default: "/etc/pki/tls/private/host.key"
+      minifi_tls_client_ca_certificate:
+        description: Path to the CA certificate file for TLS authentication.
+        type: str
+        default: "/etc/ipa/ca.crt"
+      minifi_java_service_path:
+        description: Path to the systemd service file for MiNiFi Java.
+        type: str
+        required: false
+        default: "/etc/systemd/system/minifi-java.service"
+      minifi_tls_keystore_path:
+        description: Path to the keystore file for TLS configuration.
+        type: str
+        required: false
+      minifi_tls_keystore_type:
+        description: Type of the keystore (e.g., JKS, PKCS12).
+        type: str
+        required: false
+      minifi_tls_keystore_password:
+        description: Password for the keystore file.
+        type: str
+        required: false
+      minifi_tls_key_password:
+        description: Password for the private key in the keystore.
+        type: str
+        required: false
+      minifi_tls_truststore_path:
+        description: Path to the truststore file for TLS configuration.
+        type: str
+        required: false
+      minifi_tls_truststore_type:
+        description: Type of the truststore (e.g., JKS, PKCS12).
+        type: str
+        required: false
+      minifi_tls_truststore_password:
+        description: Password for the truststore file.
+        type: str
+        required: false
+      minifi_tls_ssl_protocol:
+        description: SSL protocol to use for TLS communication (e.g., TLSv1.2).
+        type: str
+        required: false

--- a/roles/minifi_agent_java/meta/argument_specs.yml
+++ b/roles/minifi_agent_java/meta/argument_specs.yml
@@ -15,30 +15,30 @@
 
 argument_specs:
   main:
-    short_description: Install and configure Cloudera MiNiFi C++ Agent
+    short_description: Install and configure Cloudera MiNiFi Java Agent
     description:
-      - Downloads, installs, and configures Cloudera MiNiFi C++ Agent on the target host.
+      - Downloads, installs, and configures Cloudera MiNiFi Java Agent on the target host.
       - Sets up the MiNiFi properties, and manages the systemd service.
     author: Cloudera Labs
     version_added: "3.3.0"
     options:
       minifi_java_tarball_url:
-        description: URL to the MiNiFi C++ tarball to download and install.
+        description: URL to the MiNiFi Java tarball to download and install.
         type: str
         required: false
         default: "https://archive.cloudera.com/p/cem-agents/1.25.05-h2/ubuntu22/apt/tars/nifi-minifi-java/nifi-minifi-java-1.25.05-h2-b5-bin-linux.tar.gz"
       minifi_java_directory:
-        description: Directory where MiNiFi C++ will be installed.
+        description: Directory where MiNiFi Java will be installed.
         type: str
         required: false
         default: "/opt/cloudera/cem/minifi-java"
       minifi_java_properties_path:
-        description: Path to the MiNiFi C++ properties file.
+        description: Path to the MiNiFi Java properties file.
         type: str
         required: false
         default: "/opt/cloudera/cem/minifi-java/conf/minifi.properties"
       minifi_java_agent_class_name:
-        description: Agent class name for MiNiFi C++ agent.
+        description: Agent class name for MiNiFi Java agent.
         type: str
         required: false
         default: "minifi-agent-java2"
@@ -60,7 +60,7 @@ argument_specs:
         type: str
         default: "http://localhost:10090"
       minifi_tls_enabled:
-        description: Enable or disable TLS for MiNiFi C++ agent.
+        description: Enable or disable TLS for MiNiFi Java agent.
         type: bool
         default: false
       minifi_tls_client_certificate:

--- a/roles/minifi_agent_java/molecule/default/converge.yml
+++ b/roles/minifi_agent_java/molecule/default/converge.yml
@@ -1,0 +1,23 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Converge
+  hosts: all
+  gather_facts: false
+  become: false
+  tasks:
+    - name: Install and configure MiNiFi Java Agent
+      ansible.builtin.import_role:
+        name: cloudera.exe.minifi_agent_java

--- a/roles/minifi_agent_java/molecule/default/create.yml
+++ b/roles/minifi_agent_java/molecule/default/create.yml
@@ -1,0 +1,336 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: "{{ default_run_config | combine(run_config_from_file) }}"
+
+    # Platform settings handling
+    default_assign_public_ip: true
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_boot_wait_seconds: 120
+    default_instance_type: t3a.medium
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_private_key_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/id_rsa"
+    default_public_key_path: "{{ default_private_key_path }}.pub"
+    default_ssh_user: ansible
+    default_ssh_port: 22
+    default_user_data: ""
+
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_description: Ephemeral security group for Molecule instances
+    default_security_group_rules:
+      - proto: tcp
+        from_port: "{{ default_ssh_port }}"
+        to_port: "{{ default_ssh_port }}"
+        cidr_ip: "0.0.0.0/0"
+      - proto: icmp
+        from_port: 8
+        to_port: -1
+        cidr_ip: "0.0.0.0/0"
+    default_security_group_rules_egress:
+      - proto: -1
+        from_port: 0
+        to_port: 0
+        cidr_ip: "0.0.0.0/0"
+
+    platform_defaults:
+      assign_public_ip: "{{ default_assign_public_ip }}"
+      aws_profile: "{{ default_aws_profile }}"
+      boot_wait_seconds: "{{ default_boot_wait_seconds }}"
+      instance_type: "{{ default_instance_type }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      private_key_path: "{{ default_private_key_path }}"
+      public_key_path: "{{ default_public_key_path }}"
+      security_group_name: "{{ default_security_group_name }}"
+      security_group_description: "{{ default_security_group_description }}"
+      security_group_rules: "{{ default_security_group_rules }}"
+      security_group_rules_egress: "{{ default_security_group_rules_egress }}"
+      ssh_user: "{{ default_ssh_user }}"
+      ssh_port: "{{ default_ssh_port }}"
+      cloud_config: {}
+      image: ""
+      image_name: ""
+      image_owner: [self]
+      name: ""
+      region: ""
+      security_groups: []
+      tags: {}
+      volumes: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+  pre_tasks:
+    - name: Validate platform configurations
+      ansible.builtin.assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.assign_public_ip is boolean
+          - platform.aws_profile is string
+          - platform.boot_wait_seconds is integer and platform.boot_wait_seconds >= 0
+          - platform.cloud_config is mapping
+          - platform.image is string
+          - platform.image_name is string
+          - platform.image_owner is sequence or (platform.image_owner is string and platform.image_owner | length > 0)
+          - platform.instance_type is string and platform.instance_type | length > 0
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.private_key_path is string and platform.private_key_path | length > 0
+          - platform.public_key_path is string and platform.public_key_path | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_group_description is string and platform.security_group_description | length > 0
+          - platform.security_group_rules is sequence
+          - platform.security_group_rules_egress is sequence
+          - platform.security_groups is sequence
+          - platform.ssh_user is string and platform.ssh_user | length > 0
+          - platform.ssh_port is integer and platform.ssh_port in range(1, 65536)
+          - platform.tags is mapping
+          - platform.volumes is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Write run config to file
+      ansible.builtin.copy:
+        dest: "{{ run_config_path }}"
+        content: "{{ run_config | to_yaml }}"
+        mode: "0600"
+
+    - name: Generate local key pairs
+      community.crypto.openssh_keypair:
+        path: "{{ item.private_key_path }}"
+        type: rsa
+        size: 2048
+        regenerate: never
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      register: local_keypairs
+
+    - name: Look up EC2 AMI(s) by owner and name (if image not set)
+      amazon.aws.ec2_ami_info:
+        owners: "{{ item.image_owner }}"
+        filters: "{{ item.image_filters | default({}) | combine(image_name_map) }}"
+      vars:
+        image_name_map: "{% if item.image_name is defined and item.image_name | length > 0 %}{{ {'name': item.image_name} }}{% else %}{}{% endif %}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.image
+      register: ami_info
+
+    - name: Look up subnets to determine VPCs (if needed)
+      amazon.aws.ec2_vpc_subnet_info:
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      ansible.builtin.assert:
+        that:
+          - platform.image or (ami_info.results[index].images | length > 0)
+          - platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Create ephemeral EC2 keys (if needed)
+      amazon.aws.ec2_key:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        name: "{{ item.key_name }}"
+        key_material: "{{ local_keypair.public_key }}"
+      vars:
+        local_keypair: "{{ local_keypairs.results[index] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.key_inject_method == "ec2"
+      register: ec2_keys
+
+    - name: Create ephemeral security groups (if needed)
+      amazon.aws.ec2_security_group:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        iam_instance_profile: "{{ item.iam_instance_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+        name: "{{ item.security_group_name }}"
+        description: "{{ item.security_group_description }}"
+        rules: "{{ item.security_group_rules }}"
+        rules_egress: "{{ item.security_group_rules_egress }}"
+      vars:
+        vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      when: item.security_groups | length == 0
+
+    - name: Create ephemeral EC2 instance(s)
+      amazon.aws.ec2_instance:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        filters: "{{ platform_filters }}"
+        instance_type: "{{ item.instance_type }}"
+        image_id: "{{ platform_image_id }}"
+        vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+        security_groups: "{{ platform_security_groups }}"
+        network:
+          assign_public_ip: "{{ item.assign_public_ip }}"
+        volumes: "{{ item.volumes }}"
+        key_name: "{{ (item.key_inject_method == 'ec2') | ternary(item.key_name, omit) }}"
+        tags: "{{ platform_tags }}"
+        user_data: "{{ platform_user_data }}"
+        state: "running"
+        wait: true
+      vars:
+        platform_security_groups: "{{ item.security_groups or [item.security_group_name] }}"
+        platform_generated_image_id: "{{ (ami_info.results[index].images | sort(attribute='creation_date', reverse=True))[0].image_id }}"
+        platform_image_id: "{{ item.image or platform_generated_image_id }}"
+
+        platform_generated_cloud_config:
+          users:
+            - name: "{{ item.ssh_user }}"
+              ssh_authorized_keys:
+                - "{{ local_keypairs.results[index].public_key }}"
+              sudo: "ALL=(ALL) NOPASSWD:ALL"
+        platform_cloud_config: >-
+          {{ (item.key_inject_method == 'cloud-init')
+               | ternary((item.cloud_config | combine(platform_generated_cloud_config)), item.cloud_config) }}
+        platform_user_data: |-
+          #cloud-config
+          {{ platform_cloud_config | to_yaml }}
+
+        platform_generated_tags:
+          instance: "{{ item.name }}"
+          "molecule-run-id": "{{ run_config.run_id }}"
+        platform_tags: "{{ (item.tags or {}) | combine(platform_generated_tags) }}"
+        platform_filter_keys: "{{ platform_generated_tags.keys() | map('regex_replace', '^(.+)$', 'tag:\\1') }}"
+        platform_filters: "{{ dict(platform_filter_keys | zip(platform_generated_tags.values())) }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        index_var: index
+        label: "{{ item.name }}"
+      register: ec2_instances_async
+      async: 7200
+      poll: 0
+
+    - name: Instance boot block
+      when: ec2_instances_async is changed
+      block:
+        - name: Wait for instance creation to complete
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Collect instance configs
+          ansible.builtin.set_fact:
+            instance_config:
+              instance: "{{ item.name }}"
+              address: "{{ item.assign_public_ip | ternary(instance.public_ip_address, instance.private_ip_address) }}"
+              user: "{{ item.ssh_user }}"
+              port: "{{ item.ssh_port }}"
+              identity_file: "{{ item.private_key_path }}"
+              instance_ids:
+                - "{{ instance.instance_id }}"
+          vars:
+            instance: "{{ ec2_instances.results[index].instances[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          register: instance_configs
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: >-
+              {{ instance_configs.results
+                   | map(attribute='ansible_facts.instance_config')
+                   | list
+                   | to_json
+                   | from_json
+                   | to_yaml }}
+            mode: "0600"
+
+        - name: Start SSH pollers
+          ansible.builtin.wait_for:
+            host: "{{ item.address }}"
+            port: "{{ item.port }}"
+            search_regex: SSH
+            delay: 10
+            timeout: 320
+          loop: "{{ instance_configs.results | map(attribute='ansible_facts.instance_config') | list }}"
+          loop_control:
+            label: "{{ item.instance }}"
+          register: ssh_wait_async
+          async: 300
+          poll: 0
+
+        - name: Wait for SSH
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ssh_wait_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ssh_wait
+          until: ssh_wait is finished
+          retries: 300
+          delay: 1
+
+        - name: Wait for boot process to finish
+          ansible.builtin.pause:
+            seconds: "{{ platforms | map(attribute='boot_wait_seconds') | max }}"

--- a/roles/minifi_agent_java/molecule/default/destroy.yml
+++ b/roles/minifi_agent_java/molecule/default/destroy.yml
@@ -1,0 +1,157 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ molecule_no_log }}"
+  vars:
+    # Run config handling
+    default_run_id: "{{ lookup('password', '/dev/null chars=ascii_lowercase length=5') }}"
+    default_run_config:
+      run_id: "{{ default_run_id }}"
+
+    run_config_path: "{{ lookup('env', 'MOLECULE_EPHEMERAL_DIRECTORY') }}/run-config.yml"
+    run_config_from_file: "{{ (lookup('file', run_config_path, errors='ignore') or '{}') | from_yaml }}"
+    run_config: "{{ default_run_config | combine(run_config_from_file) }}"
+
+    # Platform settings handling
+    default_aws_profile: "{{ lookup('env', 'AWS_PROFILE') }}"
+    default_key_inject_method: cloud-init # valid values: [cloud-init, ec2]
+    default_key_name: "molecule-{{ run_config.run_id }}"
+    default_security_group_name: "molecule-{{ run_config.run_id }}"
+
+    platform_defaults:
+      aws_profile: "{{ default_aws_profile }}"
+      key_inject_method: "{{ default_key_inject_method }}"
+      key_name: "{{ default_key_name }}"
+      region: ""
+      security_group_name: "{{ default_security_group_name }}"
+      security_groups: []
+      vpc_id: ""
+      vpc_subnet_id: ""
+
+    # Merging defaults into a list of dicts is, it turns out, not straightforward
+    platforms: >-
+      {{ [platform_defaults | dict2items]
+           | product(molecule_yml.platforms | map('dict2items') | list)
+           | map('flatten', levels=1)
+           | list
+           | map('items2dict')
+           | list }}
+
+    # Stored instance config
+    instance_config: "{{ (lookup('file', molecule_instance_config, errors='ignore') or '{}') | from_yaml }}"
+  pre_tasks:
+    - name: Validate platform configurations
+      ansible.builtin.assert:
+        that:
+          - platforms | length > 0
+          - platform.name is string and platform.name | length > 0
+          - platform.aws_profile is string
+          - platform.key_inject_method is in ["cloud-init", "ec2"]
+          - platform.key_name is string and platform.key_name | length > 0
+          - platform.region is string
+          - platform.security_group_name is string and platform.security_group_name | length > 0
+          - platform.security_groups is sequence
+          - platform.vpc_id is string
+          - platform.vpc_subnet_id is string and platform.vpc_subnet_id | length > 0
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        label: "{{ platform.name }}"
+  tasks:
+    - name: Look up subnets to determine VPCs (if needed)
+      amazon.aws.ec2_vpc_subnet_info:
+        profile: "{{ item.aws_profile | default(omit) }}"
+        region: "{{ item.region | default(omit) }}"
+        subnet_ids: "{{ item.vpc_subnet_id }}"
+      loop: "{{ platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+      when: not item.vpc_id
+      register: subnet_info
+
+    - name: Validate discovered information
+      ansible.builtin.assert:
+        that: platform.vpc_id or (subnet_info.results[index].subnets | length > 0)
+        quiet: true
+      loop: "{{ platforms }}"
+      loop_control:
+        loop_var: platform
+        index_var: index
+        label: "{{ platform.name }}"
+
+    - name: Destroy resources
+      when: instance_config | length != 0
+      block:
+        - name: Destroy ephemeral EC2 instances
+          amazon.aws.ec2_instance:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            instance_ids: "{{ instance_config | map(attribute='instance_ids') | flatten }}"
+            vpc_subnet_id: "{{ item.vpc_subnet_id }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            label: "{{ item.name }}"
+          register: ec2_instances_async
+          async: 7200
+          poll: 0
+
+        - name: Wait for instance destruction to complete
+          ansible.builtin.async_status:
+            jid: "{{ item.ansible_job_id }}"
+          loop: "{{ ec2_instances_async.results }}"
+          loop_control:
+            index_var: index
+            label: "{{ platforms[index].name }}"
+          register: ec2_instances
+          until: ec2_instances is finished
+          retries: 300
+
+        - name: Destroy ephemeral security groups (if needed)
+          amazon.aws.ec2_security_group:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            vpc_id: "{{ item.vpc_id or vpc_subnet.vpc_id }}"
+            name: "{{ item.security_group_name }}"
+            state: absent
+          vars:
+            vpc_subnet: "{{ subnet_info.results[index].subnets[0] }}"
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.security_groups | length == 0
+
+        - name: Destroy ephemeral keys (if needed)
+          amazon.aws.ec2_key:
+            profile: "{{ item.aws_profile | default(omit) }}"
+            region: "{{ item.region | default(omit) }}"
+            name: "{{ item.key_name }}"
+            state: absent
+          loop: "{{ platforms }}"
+          loop_control:
+            index_var: index
+            label: "{{ item.name }}"
+          when: item.key_inject_method == "ec2"
+
+        - name: Write Molecule instance configs
+          ansible.builtin.copy:
+            dest: "{{ molecule_instance_config }}"
+            content: "{{ {} | to_yaml }}"

--- a/roles/minifi_agent_java/molecule/default/molecule.yml
+++ b/roles/minifi_agent_java/molecule/default/molecule.yml
@@ -1,0 +1,49 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Requires a preexisting AWS VPC and subnet, the latter referenced by the
+# environment variable, ROLE_SUBNET_ID, typically set in the Molecule ENV file
+# which is <role_path>/.env.yml
+
+# Requires AWS credentials, including region
+
+# Requires the following Python libraries on localhost
+# - netaddr
+# - boto3
+
+driver:
+  name: ec2
+platforms:
+  - name: rhel9-4.molecule.internal
+    image_owner: "309956199498"
+    image_name: RHEL-9.4.0_HVM-*
+    instance_type: t3.medium
+    boot_wait_seconds: 15
+    security_groups: ${TEST_VPC_SECURITY_GROUP}
+    vpc_subnet_id: ${TEST_VPC_SUBNET_ID}
+    tags:
+      Name: molecule-minifi_agent_java-rhel9-4
+      Project: Molecule testing for minifi_agent_java
+provisioner:
+  name: ansible
+  inventory:
+    group_vars:
+      all:
+        efm_host_url: "http://localhost:10090"
+        minifi_java_directory: "/opt/cloudera/cem/minifi-java"
+        minifi_java_properties_path: "/opt/cloudera/cem/minifi-java/conf/bootstrap.conf"
+        minifi_java_service_path: "/etc/systemd/system/minifi-java.service"
+        minifi_tls_enabled: false
+

--- a/roles/minifi_agent_java/molecule/default/molecule.yml
+++ b/roles/minifi_agent_java/molecule/default/molecule.yml
@@ -46,4 +46,3 @@ provisioner:
         minifi_java_properties_path: "/opt/cloudera/cem/minifi-java/conf/bootstrap.conf"
         minifi_java_service_path: "/etc/systemd/system/minifi-java.service"
         minifi_tls_enabled: false
-

--- a/roles/minifi_agent_java/molecule/default/requirements.yml
+++ b/roles/minifi_agent_java/molecule/default/requirements.yml
@@ -1,0 +1,21 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+collections:
+  - community.crypto
+  - amazon.aws
+  - ansible.posix
+  - ansible.utils
+  - community.general

--- a/roles/minifi_agent_java/molecule/default/verify.yml
+++ b/roles/minifi_agent_java/molecule/default/verify.yml
@@ -1,0 +1,63 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+- name: Verify MiNiFi Java Agent installation
+  hosts: all
+  gather_facts: false
+  tasks:
+    - name: Check MiNiFi Java base directory exists
+      ansible.builtin.stat:
+        path: "{{ minifi_java_directory }}"
+      register: minifi_java_dir
+
+    - name: Assert MiNiFi Java base directory exists
+      ansible.builtin.assert:
+        that:
+          - minifi_java_dir.stat.exists
+          - minifi_java_dir.stat.isdir
+
+    - name: Check MiNiFi Java properties file exists
+      ansible.builtin.stat:
+        path: "{{ minifi_java_properties_path }}"
+      register: minifi_java_properties
+
+    - name: Assert MiNiFi Java properties file exists and is a file
+      ansible.builtin.assert:
+        that:
+          - minifi_java_properties.stat.exists
+          - minifi_java_properties.stat.isfile
+
+    - name: Check MiNiFi Java systemd service file exists
+      ansible.builtin.stat:
+        path: "{{ minifi_java_service_path }}"
+      register: minifi_java_service
+
+    - name: Assert MiNiFi Java systemd service file exists
+      ansible.builtin.assert:
+        that:
+          - minifi_java_service.stat.exists
+          - minifi_java_service.stat.isfile
+
+    - name: Check if MiNiFi Java process is running
+      ansible.builtin.shell: systemctl is-active minifi-java
+      register: minifi_java_process
+      changed_when: false
+      failed_when: false
+
+    - name: Assert MiNiFi Java process is running
+      ansible.builtin.assert:
+        that:
+          - minifi_java_process.rc == 0

--- a/roles/minifi_agent_java/tasks/main.yml
+++ b/roles/minifi_agent_java/tasks/main.yml
@@ -1,0 +1,83 @@
+---
+# Copyright 2025 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Validate TLS configuration variables
+  when: minifi_tls_enabled | default(false)
+  ansible.builtin.assert:
+    that:
+      - minifi_tls_keystore_path is defined
+      - minifi_tls_keystore_type is defined
+      - minifi_tls_keystore_password is defined
+      - minifi_tls_key_password is defined
+      - minifi_tls_truststore_path is defined
+      - minifi_tls_truststore_type is defined
+      - minifi_tls_truststore_password is defined
+      - minifi_tls_ssl_protocol is defined
+    fail_msg: |
+      TLS is enabled (minifi_tls_enabled: true) but required SSL variables are missing.
+      Please define ALL of the following variables in your playbook:
+        - minifi_tls_keystore_path: "/path/to/keystore.jks"
+        - minifi_tls_keystore_type: "jks"
+        - minifi_tls_keystore_password: "your_password"
+        - minifi_tls_key_password: "your_password"
+        - minifi_tls_truststore_path: "/path/to/truststore.jks"
+        - minifi_tls_truststore_type: "jks"
+        - minifi_tls_truststore_password: "your_password"
+        - minifi_tls_ssl_protocol: "TLSv1.2"
+    success_msg: "TLS configuration variables are properly defined"
+
+- name: Create MiNiFi Java directory
+  ansible.builtin.file:
+    path: "{{ minifi_java_directory }}"
+    state: directory
+    mode: 0755
+
+- name: Create a temporary directory for MiNiFi Java tarball
+  ansible.builtin.tempfile:
+    state: directory
+  register: __minifi_java_tmp
+
+- name: Download MiNiFi Java tarball to the temporary directory
+  ansible.builtin.get_url:
+    url: "{{ minifi_java_tarball_url }}"
+    dest: "{{ __minifi_java_tmp.path }}/{{ minifi_java_tarball_url | basename }}"
+    url_username: "{{ minifi_java_repo_username | default(omit) }}"
+    url_password: "{{ minifi_java_repo_password | default(omit) }}"
+    mode: "0644"
+
+- name: Extract the MiNiFi Java tarball
+  ansible.builtin.unarchive:
+    src: "{{ __minifi_java_tmp.path }}/{{ minifi_java_tarball_url | basename }}"
+    dest: "{{ minifi_java_directory }}"
+    remote_src: true
+    extra_opts: [--strip-components=1]
+
+- name: Configure minifi.properties
+  ansible.builtin.template:
+    src: minifi.properties.j2
+    dest: "{{ minifi_java_properties_path }}"
+
+- name: Install MiNiFi Java agent
+  ansible.builtin.command: bin/minifi.sh install
+  args:
+    chdir: "{{ minifi_java_directory }}"
+
+- name: Create and enable systemd service for MiNiFi Java agent
+  become: true
+  ansible.builtin.template:
+    src: minifi-java.service.j2
+    dest: "{{ minifi_java_service_path }}"
+    mode: "0644"
+  notify: Start minifi-java service

--- a/roles/minifi_agent_java/templates/minifi-java.service.j2
+++ b/roles/minifi_agent_java/templates/minifi-java.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Apache MiNiFi Java Agent
+After=network.target
+
+[Service]
+Type=forking
+
+WorkingDirectory={{ minifi_java_directory }}
+ExecStart={{ minifi_java_directory }}/bin/minifi.sh start
+ExecStop={{ minifi_java_directory }}/bin/minifi.sh stop
+ExecReload={{ minifi_java_directory }}/bin/minifi.sh restart
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/minifi_agent_java/templates/minifi.properties.j2
+++ b/roles/minifi_agent_java/templates/minifi.properties.j2
@@ -1,0 +1,188 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Java command to use when running MiNiFi
+java=java
+
+# Username to use when running MiNiFi. This value will be ignored on Windows.
+run.as=
+
+# Configure where MiNiFi's lib and conf directories live
+# When running as a Windows service set full paths instead of relative paths
+lib.dir=./lib
+conf.dir=./conf
+
+# How long to wait after telling MiNiFi to shutdown before explicitly killing the Process
+graceful.shutdown.seconds=20
+
+# The location for the configuration file
+# When running as a Windows service use the full path to the file
+nifi.minifi.config=./conf/config.yml
+
+# Security Properties #
+# These properties take precedence over any equivalent properties specified in config.yml #
+
+#nifi.minifi.security.keystore=
+#nifi.minifi.security.keystoreType=
+#nifi.minifi.security.keystorePasswd=
+#nifi.minifi.security.keyPasswd=
+#nifi.minifi.security.truststore=
+#nifi.minifi.security.truststoreType=
+#nifi.minifi.security.truststorePasswd=
+#nifi.minifi.security.ssl.protocol=
+
+
+nifi.minifi.sensitive.props.key=
+nifi.minifi.sensitive.props.algorithm=
+
+# Provenance Reporting Properties #
+# These properties take precedence over any equivalent properties specified in the config.yml #
+nifi.minifi.provenance.reporting.comment=
+nifi.minifi.provenance.reporting.scheduling.strategy=
+nifi.minifi.provenance.reporting.scheduling.period=
+nifi.minifi.provenance.reporting.destination.url=
+nifi.minifi.provenance.reporting.input.port.name=
+nifi.minifi.provenance.reporting.instance.url=
+nifi.minifi.provenance.reporting.batch.size=
+nifi.minifi.provenance.reporting.communications.timeout=
+
+# Ignore all processor SSL controller services and use parent minifi SSL instead
+nifi.minifi.flow.use.parent.ssl=false
+
+# Notifiers to use for the associated agent, comma separated list of class names
+#nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.ingestors.RestChangeIngestor
+#nifi.minifi.notifier.ingestors=org.apache.nifi.minifi.bootstrap.configuration.ingestors.PullHttpChangeIngestor
+
+# File change notifier configuration
+
+# Path of the file to monitor for changes.  When these occur, the FileChangeNotifier, if configured, will begin the configuration reloading process
+#nifi.minifi.notifier.ingestors.file.config.path=
+# How frequently the file specified by 'nifi.minifi.notifier.file.config.path' should be evaluated for changes.
+#nifi.minifi.notifier.ingestors.file.polling.period.seconds=5
+
+# Rest change notifier configuration
+
+# Port on which the Jetty server will bind to, keep commented for a random open port
+#nifi.minifi.notifier.ingestors.receive.http.port=8338
+
+#Pull HTTP change notifier configuration
+
+# Hostname on which to pull configurations from
+#nifi.minifi.notifier.ingestors.pull.http.hostname=localhost
+# Port on which to pull configurations from
+#nifi.minifi.notifier.ingestors.pull.http.port=4567
+# Path to pull configurations from
+#nifi.minifi.notifier.ingestors.pull.http.path=/c2/config
+# Query string to pull configurations with
+#nifi.minifi.notifier.ingestors.pull.http.query=class=raspi3
+# Period on which to pull configurations from, defaults to 5 minutes if commented out
+#nifi.minifi.notifier.ingestors.pull.http.period.ms=300000
+
+# Periodic Status Reporters to use for the associated agent, comma separated list of class names
+#nifi.minifi.status.reporter.components=org.apache.nifi.minifi.bootstrap.status.reporters.StatusLogger
+
+# Periodic Status Logger configuration
+
+# The FlowStatus query to submit to the MiNiFi instance
+#nifi.minifi.status.reporter.log.query=instance:health,bulletins
+# The log level at which the status will be logged
+#nifi.minifi.status.reporter.log.level=INFO
+# The period (in milliseconds) at which to log the status
+#nifi.minifi.status.reporter.log.period=60000
+
+# Disable JSR 199 so that we can use JSP's without running a JDK
+java.arg.1=-Dorg.apache.jasper.compiler.disablejsr199=true
+
+# JVM memory settings
+java.arg.2=-Xms256m
+java.arg.3=-Xmx256m
+
+# Enable Remote Debugging
+#java.arg.debug=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8000
+
+java.arg.4=-Djava.net.preferIPv4Stack=true
+
+# allowRestrictedHeaders is required for Cluster/Node communications to work properly
+java.arg.5=-Dsun.net.http.allowRestrictedHeaders=true
+java.arg.6=-Djava.protocol.handler.pkgs=sun.net.www.protocol
+
+# Sets the provider of SecureRandom to /dev/urandom to prevent blocking on VMs
+java.arg.7=-Djava.security.egd=file:/dev/urandom
+
+
+# The G1GC is still considered experimental but has proven to be very advantageous in providing great
+# performance without significant "stop-the-world" delays.
+#java.arg.13=-XX:+UseG1GC
+
+#Set headless mode by default
+java.arg.14=-Djava.awt.headless=true
+
+# MiNiFi Command & Control Configuration
+# C2 Properties
+# Enabling C2 Uncomment each of the following options
+c2.enable=true
+## define protocol parameters
+# DEPRECATED: c2.rest.url and c2.rest.url.ack are deprecated in favor of c2.rest.path.* properties and are target to be removed in future release
+# The absolute url of the C2 server's heartbeat endpoint, eg.: http://localhost/c2-server/api/heartbeat
+#c2.rest.url=
+# The absolute url of the C2 server's acknowledge endpoint, eg.: http://localhost/c2-server/api/acknowledge
+#c2.rest.url.ack=
+# C2 Rest Path Properties
+# The base path of the C2 server's REST API, eg.: http://localhost/c2-server/api
+c2.rest.path.base={{ efm_host_url }}
+# Relative url of the C2 server's heartbeat endpoint, eg.: /heartbeat
+c2.rest.path.heartbeat=/efm/api/c2-protocol/heartbeat
+# Relative url of the C2 server's acknowledge endpoint, eg.: /acknowledge
+c2.rest.path.acknowledge=/efm/api/c2-protocol/acknowledge
+## c2 timeouts
+c2.rest.connectionTimeout=5 sec
+c2.rest.readTimeout=5 sec
+c2.rest.callTimeout=10 sec
+## heartbeat in milliseconds
+c2.agent.heartbeat.period=5000
+## define parameters about your agent
+c2.agent.class={{ minifi_java_agent_class_name }}
+c2.agent.identifier={{ minifi_java_agent_class_name }}
+c2.config.directory=./conf
+c2.runtime.manifest.identifier=minifi
+c2.runtime.type=minifi-java
+# Optional.  Defaults to a hardware based unique identifier
+# If set to false heartbeat won't contain the manifest. Defaults to true.
+c2.full.heartbeat=false
+# Directory for storing assets downloaded via C2 update/asset command
+#c2.asset.directory=./asset
+
+
+
+## Define TLS security properties for C2 communications
+
+{% if minifi_tls_enabled | default(false) %}
+c2.security.truststore.location={{ minifi_tls_truststore_path }}
+c2.security.truststore.password={{ minifi_tls_truststore_password }}
+c2.security.truststore.type={{ minifi_tls_truststore_type }}
+c2.security.keystore.location={{ minifi_tls_keystore_path }}
+c2.security.keystore.password={{ minifi_tls_keystore_password }}
+c2.security.keystore.type={{ minifi_tls_keystore_type }}
+c2.request.compression=none
+{% else %}
+#c2.security.truststore.location=
+#c2.security.truststore.password=
+#c2.security.truststore.type=
+#c2.security.keystore.location=
+#c2.security.keystore.password=
+#c2.security.keystore.type=
+#c2.request.compression=
+{% endif %}


### PR DESCRIPTION
This PR Contains:
* Ansible role which sets up MINIFI java agent 
* Initial setup and installation of the MiNiFi Java agent binaries.
*Configuration of all necessary properties, with support for both HTTP and HTTPS protocols.
* Creation and management of a systemd service for the Java Agents.