### PR TITLE
Update prereq_thp and prereq_selinux

### DIFF
--- a/roles/prereq_selinux/tasks/main.yml
+++ b/roles/prereq_selinux/tasks/main.yml
@@ -29,7 +29,17 @@
     name: "{{ selinux_packages }}"
     state: present
 
+- name: Check if SELinux is already configured to desired state
+  ansible.builtin.lineinfile:
+    path: "{{ selinux_config_file }}"
+    regexp: "^SELINUX={{ selinux_state }}$"
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: __selinux_already_set
+
 - name: Manage SELinux policy state
+  when: not __selinux_already_set.found
   ansible.posix.selinux:
     policy: "{{ selinux_policy | default(__selinux_policy) }}"
     state: "{{ selinux_state }}"

--- a/roles/prereq_thp/tasks/main.yml
+++ b/roles/prereq_thp/tasks/main.yml
@@ -90,8 +90,13 @@
 - name: Retrieve services
   ansible.builtin.service_facts:
 
+- name: Check if Cloudera tuned profile already exists
+  ansible.builtin.stat:
+    path: /etc/tuned/cldr/tuned.conf
+  register: __cldr_profile_check
+
 - name: Disable Transparent Huge Pages in tuned profile
-  when: ('tuned.service' in ansible_facts.services) and __thp.stdout is not search("\[never\]")
+  when: ('tuned.service' in ansible_facts.services) and __thp.stdout is not search("\[never\]") and not __cldr_profile_check.stat.exists
   block:
     - name: Discover current active tuned profile
       ansible.builtin.command: tuned-adm active


### PR DESCRIPTION
This PR adds a check for `/etc/tuned/cldr/tuned.conf` if it already exists it will be skipped. 