### PR TITLE
Update supported Python role

### DIFF
--- a/roles/prereq_python/tasks/RedHat.yml
+++ b/roles/prereq_python/tasks/RedHat.yml
@@ -77,13 +77,9 @@
         gather_subset:
           - python
 
-- name: Install pip
+- name: install pip
+  vars:
+    __python_version: "{{ [ansible_python['version']['major'], ansible_python['version']['minor']] | join('.') }}"
   ansible.builtin.package:
-    name: "{{ 
-      prereq_python_pip_packages | 
-      default(
-        ansible_python['version']['major'] == 3 |
-        ternary(__python3_pip_packages, __python2_pip_packages)
-      )
-    }}"
+    name: "{{ prereq_python_pip_packages | default((ansible_python['version']['major'] == 3) | ternary(__python3_pip_packages, __python2_pip_packages)) }}"
     state: present

--- a/roles/prereq_python/tasks/RedHat.yml
+++ b/roles/prereq_python/tasks/RedHat.yml
@@ -14,6 +14,11 @@
 
 ---
 
+- name: Gather Python details
+  ansible.builtin.setup:
+    gather_subset:
+      - python
+
 - name: Install supported Python
   when:
     prereq_python_upgrade and
@@ -33,23 +38,52 @@
         first |
         ansible.builtin.split(".") |
         first == "3"
-      ansible.builtin.package:
-        name: "{{ python_packages | default('python' + __python_version) }}"
-        state: present
+      block:
+        - name: Install Python3 packages
+          ansible.builtin.package:
+            name: "{{ prereq_python_packages | default(__python3_packages) }}"
+            state: present
 
-    # TODO Confirm Python2 package names
+        - name: Set installed Python as /usr/bin/python3 alternative with high priority
+          when: prereq_python_alternatives
+          community.general.alternatives:
+            name: python3
+            link: /usr/bin/python3
+            path: "{{ '/usr/bin/python' + __python_version }}"
+            priority: 100
+
     - name: Install supported version of Python2
       when:
         prereq_python_supported |
         first |
         ansible.builtin.split(".") |
         first == "2"
-      ansible.builtin.package:
-        name: "{{ python_packages | default('python' + __python_version) }}"
-        state: present
+      block:
+        - name: Install Python2 packages
+          ansible.builtin.package:
+            name: "{{ prereq_python_packages | default(__python2_packages) }}"
+            state: present
 
-# TODO Confirm Python2-pip package names
+    - name: Set installed Python as /usr/bin/python alternative with high priority
+      when: prereq_python_alternatives
+      community.general.alternatives:
+        name: python
+        link: /usr/bin/python
+        path: "{{ '/usr/bin/python' + __python_version }}"
+        priority: 100
+
+    - name: Gather distribution and Python details
+      ansible.builtin.setup:
+        gather_subset:
+          - python
+
 - name: Install pip
   ansible.builtin.package:
-    name: "{{ python_pip_packages | default('python-pip') }}"
+    name: "{{ 
+      prereq_python_pip_packages | 
+      default(
+        ansible_python['version']['major'] == 3 |
+        ternary(__python3_pip_packages, __python2_pip_packages)
+      )
+    }}"
     state: present

--- a/roles/prereq_python/tasks/RedHat.yml
+++ b/roles/prereq_python/tasks/RedHat.yml
@@ -19,18 +19,12 @@
     gather_subset:
       - python
 
-- name: Install supported Python
-  when:
-    prereq_python_upgrade and
-    prereq_python_supported is not contains(
-      [
-        ansible_python["version"]["major"],
-        ansible_python["version"]["minor"]
-      ] |
-      join(".")
-    )
-  vars:
+- name: Set Python version
+  ansible.builtin.set_fact:
     __python_version: "{{ prereq_python_supported | first | string }}"
+
+- name: Install supported Python packages
+  when: prereq_python_upgrade
   block:
     - name: Install supported version of Python3
       when:
@@ -72,14 +66,7 @@
         path: "{{ '/usr/bin/python' + __python_version }}"
         priority: 100
 
-    - name: Gather distribution and Python details
-      ansible.builtin.setup:
-        gather_subset:
-          - python
-
 - name: install pip
-  vars:
-    __python_version: "{{ [ansible_python['version']['major'], ansible_python['version']['minor']] | join('.') }}"
   ansible.builtin.package:
-    name: "{{ prereq_python_pip_packages | default((ansible_python['version']['major'] == 3) | ternary(__python3_pip_packages, __python2_pip_packages)) }}"
+    name: "{{ prereq_python_pip_packages | default((prereq_python_supported | first | ansible.builtin.split('.') | first == '3') | ternary(__python3_pip_packages, __python2_pip_packages)) }}"
     state: present

--- a/roles/prereq_python/tasks/Ubuntu.yml
+++ b/roles/prereq_python/tasks/Ubuntu.yml
@@ -135,8 +135,8 @@
 
 - name: Install pip
   ansible.builtin.package:
-    name: "{{ 
-      prereq_python_pip_packages | 
+    name: "{{
+      prereq_python_pip_packages |
       default(
         ansible_python['version']['major'] == 3 |
         ternary(__python3_pip_packages, __python2_pip_packages)

--- a/roles/prereq_python/tasks/Ubuntu.yml
+++ b/roles/prereq_python/tasks/Ubuntu.yml
@@ -14,6 +14,11 @@
 
 ---
 
+- name: Gather Python details
+  ansible.builtin.setup:
+    gather_subset:
+      - python
+
 - name: Install supported Python
   when:
     prereq_python_upgrade and
@@ -35,13 +40,13 @@
         first == "3"
       block:
         - name: Install Python3 package
-          when: python_packages is defined
+          when: prereq_python_packages is defined
           ansible.builtin.package:
-            name: "{{ python_packages }}"
+            name: "{{ prereq_python_packages }}"
             state: present
 
         - name: Install Python3 from source
-          when: python_packages is not defined
+          when: prereq_python_packages is not defined
           block:
             - name: Ensure required dependencies are installed
               ansible.builtin.package:
@@ -86,13 +91,13 @@
       block:
         # Most likely need to update this to use get-pip.py and the like
         - name: Install Python2 package
-          when: python_packages is defined
+          when: prereq_python_packages is defined
           ansible.builtin.package:
-            name: "{{ python_packages }}"
+            name: "{{ prereq_python_packages }}"
             state: present
 
         - name: Install Python2 from source
-          when: python_packages is not defined
+          when: prereq_python_packages is not defined
           block:
             - name: Ensure required dependencies are installed
               ansible.builtin.package:
@@ -128,8 +133,13 @@
                 chdir: /tmp/Python-{{ __python_version }}
                 target: altinstall
 
-# TODO Confirm Python2-pip package names
-- name: Ensure pip is installed
+- name: Install pip
   ansible.builtin.package:
-    name: "{{ python_pip_packages | default('python3-pip') }}"
+    name: "{{ 
+      prereq_python_pip_packages | 
+      default(
+        ansible_python['version']['major'] == 3 |
+        ternary(__python3_pip_packages, __python2_pip_packages)
+      )
+    }}"
     state: present

--- a/roles/prereq_python/tasks/main.yml
+++ b/roles/prereq_python/tasks/main.yml
@@ -48,8 +48,7 @@
       and Cloudera Runtime {{ cloudera_runtime_version }}"
 
 - name: Load OS-specific variables
-  ansible.builtin.include_vars:
-    file: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
     - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
@@ -70,7 +69,20 @@
     - "{{ ansible_facts['os_family'] }}.yml"
     - "default.yml"
 
+- name: Set pip executable path
+  ansible.builtin.set_fact:
+    __pip_executable: "{{ '/usr/bin/pip' + (prereq_python_supported | first | string) }}"
+
 - name: Ensure pip is upgraded
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+    executable: "{{ __pip_executable }}"
+
+- name: Create symlink for pip3 to installed version
+  when: prereq_python_supported | first | ansible.builtin.split('.') | first == '3'
+  ansible.builtin.file:
+    src: "{{ __pip_executable }}"
+    dest: /usr/bin/pip3
+    state: link
+    force: true

--- a/roles/prereq_python/tasks/main.yml
+++ b/roles/prereq_python/tasks/main.yml
@@ -13,11 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Gather distribution and Python details
+- name: Gather distribution details
   ansible.builtin.setup:
     gather_subset:
       - distribution
-      - python
 
 - name: Gather supported Python versions for Cloudera Runtime and Manager versions and OS
   ansible.builtin.set_fact:
@@ -47,6 +46,18 @@
       "{{ ansible_facts['distribution'] }} {{ ansible_facts['distribution_version'] }}
       is not supported by Cloudera Manager {{ cloudera_manager_version }}
       and Cloudera Runtime {{ cloudera_runtime_version }}"
+
+- name: Load OS-specific variables
+  ansible.builtin.include_vars:
+    file: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['distribution'] }}.yml"
+    - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_version'] }}.yml"
+    - "{{ ansible_facts['os_family'] }}-{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ ansible_facts['os_family'] }}.yml"
+    - "default.yml"
 
 - name: Update or install Python
   ansible.builtin.include_tasks: "{{ item }}"

--- a/roles/prereq_python/vars/RedHat.yml
+++ b/roles/prereq_python/vars/RedHat.yml
@@ -20,19 +20,12 @@ __python3_packages:
   - "python{{ __python_version }}"
   - "python{{ __python_version }}-libs"
   - "python{{ __python_version }}-devel"
-  - krb5-devel
-  - gcc
-  - libffi-devel
-  - openssl-devel
+  - "python{{ __python_version }}-setuptools"
 
 __python2_packages:
   - "python{{ __python_version }}"
   - "python{{ __python_version }}-libs"
   - "python{{ __python_version }}-devel"
-  - krb5-devel
-  - gcc
-  - libffi-devel
-  - openssl-devel
 
 __python3_pip_packages:
   - "python{{ __python_version }}-pip"

--- a/roles/prereq_python/vars/RedHat.yml
+++ b/roles/prereq_python/vars/RedHat.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+
+prereq_python_alternatives: true
+
+__python3_packages:
+  - "python{{ __python_version }}"
+  - "python{{ __python_version }}-libs"
+  - "python{{ __python_version }}-devel"
+  - krb5-devel
+  - gcc
+  - libffi-devel
+  - openssl-devel
+
+__python2_packages:
+  - "python{{ __python_version }}"
+  - "python{{ __python_version }}-libs"
+  - "python{{ __python_version }}-devel"
+  - krb5-devel
+  - gcc
+  - libffi-devel
+  - openssl-devel
+
+__python3_pip_packages:
+  - "python{{ __python_version }}-pip"
+
+__python2_pip_packages:
+  - "python{{ __python_version }}-pip"

--- a/roles/prereq_python/vars/default.yml
+++ b/roles/prereq_python/vars/default.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2025 Cloudera, Inc.
+# Copyright 2026 Cloudera, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cloudera_manager_version: "{{ undef(hint='Please specify the Cloudera Manager version') }}"
-cloudera_runtime_version: "{{ undef(hint='Please specify the Cloudera Runtime version') }}"
+__python3_packages:
+  - python3
 
-# prereq_python_packages:
-# prereq_python_pip_packages:
+__python2_packages:
+  - python
 
-prereq_python_upgrade: true
-prereq_python_alternatives: false
+__python3_pip_packages:
+  - python3-pip
+
+__python2_pip_packages:
+  - python-pip

--- a/roles/prereq_python/vars/main.yml
+++ b/roles/prereq_python/vars/main.yml
@@ -13,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__python3_package: python
-__python3_pip_package: python-pip
-
-__python2_package: python
-__python2_pip_package: python-pip
-
 prereq_python_supported_os_map:
   RedHat: RHEL
   Rocky: "Rocky Linux"


### PR DESCRIPTION
Abstract the distribution/OS within the prereq_python role to handle better the variations between supported OS, notably RHEL. This includes alternatives and system Python libraries.