### PR TITLE
Add Python interpreter variables for FreeIPA server roles

### DIFF
--- a/roles/freeipa_server/tasks/main.yml
+++ b/roles/freeipa_server/tasks/main.yml
@@ -44,11 +44,14 @@
   loop: "{{ freeipa_server_packages }}"
   loop_control:
     loop_var: __ipa_package
+  vars:
+    ansible_python_interpreter: "{{ __freeipa_python_interpreter }}"
 
 - name: Set up the FreeIPA Server
   ansible.builtin.import_role:
     name: freeipa.ansible_freeipa.ipaserver
   vars:
+    ansible_python_interpreter: "{{ __freeipa_python_interpreter }}"
     state: present
     ipaserver_hostname: "{{ inventory_hostname }}"
     # ipaserver_no_host_dns: yes # redundant with ipaserver_setup_dns

--- a/roles/freeipa_server/vars/RedHat.yml
+++ b/roles/freeipa_server/vars/RedHat.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2026 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__freeipa_python_interpreter: "/usr/libexec/platform-python"

--- a/roles/freeipa_server/vars/main.yml
+++ b/roles/freeipa_server/vars/main.yml
@@ -1,0 +1,16 @@
+---
+# Copyright 2026 Cloudera, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__freeipa_python_interpreter: "/usr/bin/python3"


### PR DESCRIPTION

* Added an OS-specific override for RedHat-based systems in `roles/freeipa_server/vars/RedHat.yml`, setting `__freeipa_python_interpreter` to `/usr/libexec/platform-python`.